### PR TITLE
Python3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ keys/cloudgoat_key*
 credentials.txt
 keys/pgp_cloudgoat
 allow_cidr.txt
+tmp/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 Rhino Security Labs' "Vulnerable by Design" AWS infrastructure setup tool
 
 ## Requirements
-- Python2  
+- Python2 or Python3  
 - Terraform in your $PATH (https://www.terraform.io/downloads.html)  
 - gpg (`apt-get install gpg`)  
 - OpenSSH (For SSH key generation)  
+
+## Warning
+- **CloudGoat deploys intentionally vulnerable AWS resources into your account. DO NOT deploy CloudGoat in a production environment or alongside any sensitive AWS resources.**  
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Rhino Security Labs' "Vulnerable by Design" AWS infrastructure setup tool
 
 ## Requirements
-- Python2 or Python3  
+- Python2  
 - Terraform in your $PATH (https://www.terraform.io/downloads.html)  
 - gpg (`apt-get install gpg`)  
 - OpenSSH (For SSH key generation)  
@@ -19,4 +19,4 @@ Now the credentials to get you started will be stored in ./credentials.txt and i
 1. `./kill.sh`  
 
 ## Note about AWS Glue, why it's disabled, and how to re-enable it
-- The Glue development endpoint is disabled by default due to it costing far more than the whole rest of CloudGoat to run. If you would like to enable the Glue development endpoint (estimated at $1 per hour), uncomment the final three lines of "start.sh", uncomment the final eight lines of "kill.sh", and uncomment the file located at "./terraform/glue.tf".
+- The Glue development endpoint is disabled by default due to it costing far more than the whole rest of CloudGoat to run. If you would like to enable the Glue development endpoint (estimated at $1 per hour), uncomment the final three lines of "start.sh", uncomment the final eight lines of "kill.sh", uncomment the final two lines of "extract_creds.py", and uncomment the file located at "./terraform/glue.tf".

--- a/extract_creds.py
+++ b/extract_creds.py
@@ -17,5 +17,6 @@ with open('./terraform/terraform.tfstate') as tfstate:
     credfile.write("Joe's Access Key:         " + data['modules'][0]['resources']['aws_iam_access_key.joe_key']['primary']['id'] + "\n")
     credfile.write("Joe's Secret Key:         " + data['modules'][0]['resources']['aws_iam_access_key.joe_key']['primary']['attributes']['secret'] + "\n" )
 
-  with open('./tmp/glue_role_arn.txt', 'w+') as glue_file:
-    glue_file.write(data['modules'][0]['resources']['aws_iam_role.glue_dev_endpoint']['primary']['attributes']['arn'])
+# Uncomment the follow two lines if you are enabling the Glue development endpoint
+#  with open('./tmp/glue_role_arn.txt', 'w+') as glue_file:
+#    glue_file.write(data['modules'][0]['resources']['aws_iam_role.glue_dev_endpoint']['primary']['attributes']['arn'])

--- a/extract_creds.py
+++ b/extract_creds.py
@@ -10,7 +10,7 @@ with open('./terraform/terraform.tfstate') as tfstate:
     encryptpass = data['modules'][0]['resources']['aws_iam_user_login_profile.administrator']['primary']['attributes']['encrypted_password']
     echovar = subprocess.Popen(["echo", encryptpass], stdout=subprocess.PIPE)
     decodepass = subprocess.Popen(["base64", "--decode"], stdin=echovar.stdout, stdout=subprocess.PIPE)
-    clearpass = subprocess.Popen(["gpg", "--decrypt"], stdin=decodepass.stdout, stdout=subprocess.PIPE).stdout.read()
+    clearpass = subprocess.Popen(["gpg", "--decrypt"], stdin=decodepass.stdout, stdout=subprocess.PIPE).stdout.read().decode("utf-8")
     credfile.write("Administrator Password:   " + clearpass + '\n')
     credfile.write("Bob's Access Key:         " + data['modules'][0]['resources']['aws_iam_access_key.bob_key']['primary']['id'] + "\n")
     credfile.write("Bob's Secret Key:         " + data['modules'][0]['resources']['aws_iam_access_key.bob_key']['primary']['attributes']['secret'] + "\n" )

--- a/start.sh
+++ b/start.sh
@@ -45,7 +45,7 @@ terraform init
 terraform plan -var cloudgoat_private_bucket_name=$cloudgoat_private_bucket_name -var ec2_web_app_password=$ec2_web_app_password -var cloudgoat_public_bucket_name=$cloudgoat_public_bucket_name -var ec2_public_key="`cat ../keys/cloudgoat_key.pub`" -out plan.tfout
 terraform apply -auto-approve plan.tfout
 
-cd .. && ./extract_creds.py
+cd .. && python ./extract_creds.py
 
 ## Uncomment the follow three lines to enable the Glue development endpoint (make sure to uncomment the specified lines in "kill.sh"
 #glue_dev_endpoint_name=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)

--- a/start.sh
+++ b/start.sh
@@ -45,7 +45,7 @@ terraform init
 terraform plan -var cloudgoat_private_bucket_name=$cloudgoat_private_bucket_name -var ec2_web_app_password=$ec2_web_app_password -var cloudgoat_public_bucket_name=$cloudgoat_public_bucket_name -var ec2_public_key="`cat ../keys/cloudgoat_key.pub`" -out plan.tfout
 terraform apply -auto-approve plan.tfout
 
-cd .. && python ./extract_creds.py
+cd .. && ./extract_creds.py
 
 ## Uncomment the follow three lines to enable the Glue development endpoint (make sure to uncomment the specified lines in "kill.sh"
 #glue_dev_endpoint_name=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)


### PR DESCRIPTION
Addresses issue #9 (https://github.com/RhinoSecurityLabs/cloudgoat/issues/9). Python3 officially works now

Added warning to README

Fixed an error in extract_creds.py with Glue disabled