### PR TITLE
Use cgid in resource names for iam_privesc_by_rollback

### DIFF
--- a/scenarios/iam_privesc_by_rollback/terraform/iam.tf
+++ b/scenarios/iam_privesc_by_rollback/terraform/iam.tf
@@ -1,23 +1,26 @@
 #IAM Users
 resource "aws_iam_user" "cg-raynor" {
-  name = "raynor"
+  name = "raynor-${var.cgid}"
   tags = {
-    Name = "cg-raynor-${var.cgid}"
-    Stack = "${var.stack-name}"
+    Name     = "cg-raynor-${var.cgid}"
+    Stack    = "${var.stack-name}"
     Scenario = "${var.scenario-name}"
   }
 }
+
 resource "aws_iam_access_key" "cg-raynor" {
   user = "${aws_iam_user.cg-raynor.name}"
 }
+
 #IAM User Policies
 resource "aws_iam_policy" "cg-raynor-policy" {
-  name = "cg-raynor-policy"
+  name        = "cg-raynor-policy-${var.cgid}"
   description = "cg-raynor-policy"
-  policy = "${file("../assets/policies/v1.json")}"
+  policy      = "${file("../assets/policies/v1.json")}"
 }
+
 #IAM Policy Attachments
 resource "aws_iam_user_policy_attachment" "cg-raynor-attachment" {
-  user = "${aws_iam_user.cg-raynor.name}"
+  user       = "${aws_iam_user.cg-raynor.name}"
   policy_arn = "${aws_iam_policy.cg-raynor-policy.arn}"
 }

--- a/scenarios/iam_privesc_by_rollback/terraform/outputs.tf
+++ b/scenarios/iam_privesc_by_rollback/terraform/outputs.tf
@@ -9,3 +9,11 @@ output "cloudgoat_output_raynor_secret_key" {
 output "cloudgoat_output_aws_account_id" {
   value = "${data.aws_caller_identity.aws-account-id.account_id}"
 }
+
+output "cloudgoat_output_policy_arn" {
+  value = "${aws_iam_policy.cg-raynor-policy.arn}"
+}
+
+output "cloudgoat_output_username" {
+  value = "${aws_iam_user.cg-raynor.name}"
+}


### PR DESCRIPTION
This is to match the other scenarios and allow running multiple copies of the same scenario in a single AWS account.