### PR TITLE
Update cheat sheets and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Before you proceed, please take note of these warnings!
   * Argument tab-completion requires bash 4.2+ (Linux, or OSX with some difficulty).
 * Python3.6+ is required.
 * Terraform 0.12 [installed and in your $PATH](https://learn.hashicorp.com/terraform/getting-started/install.html).
-* The AWS CLI [installed and in your $PATH](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html), and an AWS account with sufficient privileges to create and destroy resources.
+* The AWS CLI v1 [installed and in your $PATH](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html), and an AWS account with sufficient privileges to create and destroy resources.
 
 ## Quick Start
 

--- a/scenarios/iam_privesc_by_attachment/cheat_sheet_kerrigan.md
+++ b/scenarios/iam_privesc_by_attachment/cheat_sheet_kerrigan.md
@@ -18,10 +18,6 @@
 
 `aws ec2 run-instances --image-id ami-0a313d6098716f372 --iam-instance-profile Arn=<instanceProfileArn> --key-name kerrigan --profile kerrigan --subnet-id <subnetId> --security-group-ids <securityGroupId>`
 
-`sudo apt-get update`
-
-`sudo apt-get install awscli`
-
 `aws ec2 describe-instances --region us-east-1`
 
 `aws ec2 terminate-instances --instance-ids <instanceId> --region us-east-1`

--- a/scenarios/iam_privesc_by_rollback/cheat_sheet_raynor.md
+++ b/scenarios/iam_privesc_by_rollback/cheat_sheet_raynor.md
@@ -1,6 +1,6 @@
 `aws configure --profile Raynor`
 
-`aws iam list-attached-user-policies --user-name raynor --profile Raynor`
+`aws iam list-attached-user-policies --user-name Raynor --profile Raynor`
 
 `aws iam list-policy-versions --policy-arn <generatedARN>/cg-raynor-policy --profile Raynor`
 

--- a/scenarios/iam_privesc_by_rollback/cheat_sheet_raynor.md
+++ b/scenarios/iam_privesc_by_rollback/cheat_sheet_raynor.md
@@ -1,4 +1,4 @@
-`aws configure --profile raynor`
+`aws configure --profile Raynor`
 
 `aws iam list-attached-user-policies --user-name raynor --profile Raynor`
 


### PR DESCRIPTION
Made the following changes:
1. Made Raynor profile name capitalization consistent in rollback cheatsheet
2. Removed unnecessary update/install commands from privesc by attachment cheatsheet
3. Specified AWS CLI v1 as a requirement (v2 didn't work when I tried it)