### PR TITLE
Update ec2.tf

### DIFF
--- a/scenarios/ec2_ssrf/terraform/ec2.tf
+++ b/scenarios/ec2_ssrf/terraform/ec2.tf
@@ -140,7 +140,7 @@ resource "aws_instance" "cg-ubuntu-ec2" {
         #!/bin/bash
         apt-get update
         curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-        apt-get install -y nodejs unzip
+        DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs unzip
         npm install http express needle command-line-args
         cd /home/ubuntu
         unzip app.zip -d ./app


### PR DESCRIPTION
During the install, an interactive prompt for OpenSSL would halt the install of the webserver. Adding this line will make sure interactive prompts do not halt the install.
#50 