### PR TITLE
Update cheat_sheet_mcduck.md

### DIFF
--- a/scenarios/rce_web_app/cheat_sheet_mcduck.md
+++ b/scenarios/rce_web_app/cheat_sheet_mcduck.md
@@ -12,6 +12,8 @@
 
 `chmod 400 cloudgoat`
 
+`ssh -i cloudgoat ubuntu@<ec2_ip>
+
 `sudo apt-get install awscli`
 
 `aws s3 ls`


### PR DESCRIPTION
Added step `ssh -i cloudgoat ubuntu@` because it was missing. Adding this step makes it clear that you need to login to the ec2 instance to continue the challenge.