### PR TITLE
Update ec2.tf in rce_web_app

### DIFF
--- a/scenarios/rce_web_app/terraform/ec2.tf
+++ b/scenarios/rce_web_app/terraform/ec2.tf
@@ -144,7 +144,7 @@ resource "aws_instance" "cg-ubuntu-ec2" {
         #!/bin/bash
         apt-get update
         curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-        apt-get install -y nodejs postgresql-client unzip
+        DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs postgresql-client unzip
         psql postgresql://${var.rds-username}:${var.rds-password}@${aws_db_instance.cg-psql-rds.endpoint}/cloudgoat \
         -c "CREATE TABLE sensitive_information (name VARCHAR(50) NOT NULL, value VARCHAR(50) NOT NULL);"
         psql postgresql://${var.rds-username}:${var.rds-password}@${aws_db_instance.cg-psql-rds.endpoint}/cloudgoat \


### PR DESCRIPTION
During the install, an interactive prompt for OpenSSL would halt the install of the webserver. Adding this line will make sure interactive prompts do not halt the install. #50 