### PR TITLE
Update profile name for run-instances command

### DIFF
--- a/scenarios/iam_privesc_by_attachment/cheat_sheet_kerrigan.md
+++ b/scenarios/iam_privesc_by_attachment/cheat_sheet_kerrigan.md
@@ -16,7 +16,7 @@
 
 `aws ec2 describe-security-groups --profile Kerrigan`
 
-`aws ec2 run-instances --image-id ami-0a313d6098716f372 --iam-instance-profile Arn=<instanceProfileArn> --key-name pwned --profile kerrigan --subnet-id <subnetId> --security-group-ids <securityGroupId>`
+`aws ec2 run-instances --image-id ami-0a313d6098716f372 --iam-instance-profile Arn=<instanceProfileArn> --key-name pwned --profile Kerrigan --subnet-id <subnetId> --security-group-ids <securityGroupId>`
 
 `sudo apt-get update`
 


### PR DESCRIPTION
The following line contain a typo error, the profile name does not start with an uppercase, `--profile kerrigan` should be `--profile Kerrigan`:
`aws ec2 run-instances --image-id ami-0a313d6098716f372 --iam-instance-profile Arn=<instanceProfileArn> --key-name pwned --profile kerrigan --subnet-id <subnetId> --security-group-ids <securityGroupId>`