### PR TITLE
Typo fix in ecs_efs_attack cheatsheet command to list the privileges

### DIFF
--- a/scenarios/ecs_efs_attack/cheat_sheet.md
+++ b/scenarios/ecs_efs_attack/cheat_sheet.md
@@ -7,7 +7,7 @@
     `aws configure --profile ruse`
 
 3. List the privileges 
-`aws iam list --profile ruse`
+`aws iam list-policies --profile ruse`
 
 4. List ec2 instances 
 


### PR DESCRIPTION
Fix typo in  ecs_efs_attack cheatsheet command to list the privileges(Point 3 in cheatsheet - scenarios/ecs_efs_attack/cheat_sheet.md )

Present command - aws iam list --profile ruse
Fixed command - aws iam list-policies --profile ruse