### PR TITLE
Fixed version check for terraform destroy command.

### DIFF
--- a/core/python/python_terraform/__init__.py
+++ b/core/python/python_terraform/__init__.py
@@ -141,7 +141,7 @@ class Terraform(object):
         :return: ret_code, stdout, stderr
         """
         default = kwargs
-        if 0.15 >= self.version():
+        if 0.15 <= self.version():
             default['auto-approve'] = force
         else:
             default['force'] = force


### PR DESCRIPTION
The comparison check is backwards and break versions other than 0.15. This change fixes the comparison check.