### PR TITLE
Help fixes + change create to always runs apply

### DIFF
--- a/cloudgoat.py
+++ b/cloudgoat.py
@@ -52,13 +52,16 @@ def parse_args():
     parser = argparse.ArgumentParser(add_help=False, usage="cloudgoat.py help")
 
     parser.add_argument(
-        "command", nargs="+", action="store"
+        "command", nargs="*", action="store"
     ).completer = command_completer
     parser.add_argument(
         "-a", "--auto", required=False, action="store_true", help=argparse.SUPPRESS
     )
     parser.add_argument(
-        "-p", "--profile", required=False, action="store", help=argparse.SUPPRESS
+        "-p", "--profile", action='store_true', help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        "-h", "--help", action='store_true', help=argparse.SUPPRESS
     )
 
     try:

--- a/core/python/python_terraform/__init__.py
+++ b/core/python/python_terraform/__init__.py
@@ -4,6 +4,7 @@
 import subprocess
 import os
 import sys
+import signal
 import json
 import logging
 import tempfile
@@ -66,6 +67,7 @@ class Terraform(object):
         :type is_env_vars_included: bool
         :param is_env_vars_included: included env variables when calling terraform cmd
         """
+        self.caught_sigint = False
         self.is_env_vars_included = is_env_vars_included
         self.working_dir = working_dir
         self.state = state
@@ -254,6 +256,10 @@ class Terraform(object):
         cmds += args
         return cmds
 
+    def sigint_handler(self, signum, frame):
+        self.caught_sigint = True
+        print("Waiting for terraform to finish before exiting.")
+
     def cmd(self, cmd, *args, **kwargs) -> (int, str, str):
         """
         run a terraform command, if success, will try to read state file
@@ -281,6 +287,7 @@ class Terraform(object):
                       err: The captured stderr, or None if not captured
         :return: ret_code, out, err
         """
+        signal.signal(signal.SIGINT, self.caught_sigint)
         capture_output = kwargs.pop('capture_output', True)
         raise_on_error = kwargs.pop('raise_on_error', False)
         if capture_output is True:
@@ -326,6 +333,9 @@ class Terraform(object):
         if ret_code != 0 and raise_on_error:
             raise TerraformCommandError(
                 ret_code, ' '.join(cmds), out=out, err=err)
+
+        if self.caught_sigint:
+            raise KeyboardInterrupt()
 
         return ret_code, out, err
 

--- a/core/python/tests.py
+++ b/core/python/tests.py
@@ -1,15 +1,20 @@
+#!/usr/bin/env python3
 import os
 import sys
 import unittest
+import unittest.mock
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".."))
 )
 
+import core.python.utils
+
 from core.python.utils import (
     extract_cgid_from_dir_name,
     ip_address_or_range_is_valid,
     normalize_scenario_name,
+    find_scenario_instance_dir,
 )
 
 
@@ -215,6 +220,19 @@ class TestUtilityFunctions(unittest.TestCase):
             ),
             "codebuild_secrets",
         )
+
+
+class TestCloudGoatClass(unittest.TestCase):
+    def test_find_scenario_instance_dir(self):
+        core.python.utils.dirs_at_location = unittest.mock.Mock(return_value=[
+            '/tmp/other_scenario_takeover_cgid5o8kwrb5ir',
+            '/tmp/ecs_takeover_cgidkcjqvxvjh8',
+        ])
+        self.assertEqual(
+            find_scenario_instance_dir('/tmp', 'ecs_takeover'),
+            '/tmp/ecs_takeover_cgidkcjqvxvjh8',
+        )
+        core.python.utils.dirs_at_location.assert_called_with('/tmp')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Change the behavior of running create on an existing scenario. Previously this would destroy and create the deployment, this is problematic when you want to make minor changes to a scenario and isn't terribly useful in other cases (destroy + create can always be run separately).
* Fix help output when no commands are passed.