### PR TITLE
Ensure resource names (S3 bucket, RDS, load balancer) do not contain invalid characters (closes #98, #100)

### DIFF
--- a/scenarios/cloud_breach_s3/terraform/s3.tf
+++ b/scenarios/cloud_breach_s3/terraform/s3.tf
@@ -1,10 +1,17 @@
 #Secret S3 Bucket
+locals {
+  # Ensure the bucket suffix doesn't contain invalid characters
+  # "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
+  # (per https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) 
+  bucket_suffix = replace(var.cgid, "/[^a-z0-9-.]/", "-")
+}
+
 resource "aws_s3_bucket" "cg-cardholder-data-bucket" {
-  bucket = "cg-cardholder-data-bucket-${var.cgid}"
+  bucket = "cg-cardholder-data-bucket-${local.bucket_suffix}"
   acl = "private"
   force_destroy = true
   tags = {
-      Name = "cg-cardholder-data-bucket-${var.cgid}"
+      Name = "cg-cardholder-data-bucket-${local.bucket_suffix}"
       Description = "CloudGoat ${var.cgid} S3 Bucket used for storing sensitive cardholder data."
       Stack = "${var.stack-name}"
       Scenario = "${var.scenario-name}"

--- a/scenarios/ec2_ssrf/terraform/s3.tf
+++ b/scenarios/ec2_ssrf/terraform/s3.tf
@@ -1,10 +1,17 @@
 #Secret S3 Bucket
+locals {
+  # Ensure the bucket suffix doesn't contain invalid characters
+  # "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
+  # (per https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) 
+  bucket_suffix = replace(var.cgid, "/[^a-z0-9-.]/", "-")
+}
+
 resource "aws_s3_bucket" "cg-secret-s3-bucket" {
-  bucket = "cg-secret-s3-bucket-${var.cgid}"
+  bucket = "cg-secret-s3-bucket-${local.bucket_suffix}"
   acl = "private"
   force_destroy = true
   tags = {
-      Name = "cg-secret-s3-bucket-${var.cgid}"
+      Name = "cg-secret-s3-bucket-${local.bucket_suffix}"
       Description = "CloudGoat ${var.cgid} S3 Bucket used for storing a secret"
       Stack = "${var.stack-name}"
       Scenario = "${var.scenario-name}"

--- a/scenarios/rce_web_app/terraform/iam.tf
+++ b/scenarios/rce_web_app/terraform/iam.tf
@@ -35,14 +35,14 @@ resource "aws_iam_policy" "cg-lara-policy" {
         "s3:ListBucket"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::cg-logs-s3-bucket-${var.cgid}"
+      "Resource": "arn:aws:s3:::cg-logs-s3-bucket-${local.cgid_suffix}"
     },
     {
       "Action": [
         "s3:GetObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::cg-logs-s3-bucket-${var.cgid}/*"
+      "Resource": "arn:aws:s3:::cg-logs-s3-bucket-${local.cgid_suffix}/*"
     },
     {
       "Action": [
@@ -79,14 +79,14 @@ resource "aws_iam_policy" "cg-mcduck-policy" {
         "s3:ListBucket"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::cg-keystore-s3-bucket-${var.cgid}"
+      "Resource": "arn:aws:s3:::cg-keystore-s3-bucket-${local.cgid_suffix}"
     },
     {
       "Action": [
         "s3:GetObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::cg-keystore-s3-bucket-${var.cgid}/*"
+      "Resource": "arn:aws:s3:::cg-keystore-s3-bucket-${local.cgid_suffix}/*"
     },
     {
       "Action": [

--- a/scenarios/rce_web_app/terraform/lb.tf
+++ b/scenarios/rce_web_app/terraform/lb.tf
@@ -1,6 +1,6 @@
 #Security Groups
 resource "aws_security_group" "cg-lb-http-security-group" {
-  name = "cg-lb-http-${var.cgid}"
+  name = "cg-lb-http-${local.cgid_suffix}"
   description = "CloudGoat ${var.cgid} Security Group for Application Load Balancer over HTTP"
   vpc_id = "${aws_vpc.cg-vpc.id}"
   ingress {
@@ -18,14 +18,14 @@ resource "aws_security_group" "cg-lb-http-security-group" {
       ]
   }
   tags = {
-    Name = "cg-lb-http-${var.cgid}"
+    Name = "cg-lb-http-${local.cgid_suffix}"
     Stack = "${var.stack-name}"
     Scenario = "${var.scenario-name}"
   }
 }
 #Application Load Balancer
 resource "aws_lb" "cg-lb" {
-  name = "cg-lb-${var.cgid}"
+  name = "cg-lb-${local.cgid_suffix}"
   internal = false
   load_balancer_type = "application"
   ip_address_type = "ipv4"
@@ -49,13 +49,14 @@ resource "aws_lb" "cg-lb" {
 }
 #Target Group
 resource "aws_lb_target_group" "cg-target-group" {
-  name = "cg-target-group-${var.cgid}"
+  # Note: the name cannot be more than 32 characters
+  name = "cg-tg-${local.cgid_suffix}"
   port = 9000
   protocol = "HTTP"
   vpc_id = "${aws_vpc.cg-vpc.id}"
   target_type = "instance"
   tags = {
-    Name = "cg-target-group-${var.cgid}"
+    Name = "cg-target-group-${local.cgid_suffix}"
     Stack = "${var.stack-name}"
     Scenario = "${var.scenario-name}"
   }

--- a/scenarios/rce_web_app/terraform/locals.tf
+++ b/scenarios/rce_web_app/terraform/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  # Ensure resource suffixes the bucket suffix doesn't contain anything else than
+  # lowercase letters, numbers, and hyphens
+  # Used for RDS, load balancer and S3
+  cgid_suffix = replace(var.cgid, "/[^a-z0-9-]/", "-")
+}

--- a/scenarios/rce_web_app/terraform/rds.tf
+++ b/scenarios/rce_web_app/terraform/rds.tf
@@ -44,7 +44,7 @@ resource "aws_db_subnet_group" "cg-rds-subnet-group" {
 }
 #RDS PostgreSQL Instance
 resource "aws_db_instance" "cg-psql-rds" {
-  identifier = "cg-rds-instance-${var.cgid}"
+  identifier = "cg-rds-instance-${local.cgid_suffix}"
   engine = "postgres"
   engine_version = "9.6"
   port = "5432"

--- a/scenarios/rce_web_app/terraform/s3.tf
+++ b/scenarios/rce_web_app/terraform/s3.tf
@@ -1,3 +1,10 @@
+locals {
+  # Ensure the bucket suffix doesn't contain invalid characters
+  # "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
+  # (per https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) 
+  bucket_suffix = replace(var.cgid, "/[^a-z0-9-.]/", "-")
+}
+
 #Logs S3 Bucket Policy
 resource "aws_s3_bucket_policy" "cg-logs-s3-bucket-policy" {
   bucket = "${aws_s3_bucket.cg-logs-s3-bucket.id}"
@@ -25,11 +32,11 @@ POLICY
 }
 #Logs S3 Bucket
 resource "aws_s3_bucket" "cg-logs-s3-bucket" {
-  bucket = "cg-logs-s3-bucket-${var.cgid}"
+  bucket = "cg-logs-s3-bucket-${local.bucket_suffix}"
   acl = "private"
   force_destroy = true
   tags = {
-      Name = "cg-logs-s3-bucket-${var.cgid}"
+      Name = "cg-logs-s3-bucket-${local.bucket_suffix}"
       Description = "CloudGoat ${var.cgid} S3 Bucket used for ALB Logs"
       Stack = "${var.stack-name}"
       Scenario = "${var.scenario-name}"
@@ -37,11 +44,11 @@ resource "aws_s3_bucket" "cg-logs-s3-bucket" {
 }
 #Secret S3 Bucket
 resource "aws_s3_bucket" "cg-secret-s3-bucket" {
-  bucket = "cg-secret-s3-bucket-${var.cgid}"
+  bucket = "cg-secret-s3-bucket-${local.bucket_suffix}"
   acl = "private"
   force_destroy = true
   tags = {
-      Name = "cg-secret-s3-bucket-${var.cgid}"
+      Name = "cg-secret-s3-bucket-${local.bucket_suffix}"
       Description = "CloudGoat ${var.cgid} S3 Bucket used for storing a secret"
       Stack = "${var.stack-name}"
       Scenario = "${var.scenario-name}"
@@ -49,11 +56,11 @@ resource "aws_s3_bucket" "cg-secret-s3-bucket" {
 }
 #Keystore S3 Bucket
 resource "aws_s3_bucket" "cg-keystore-s3-bucket" {
-  bucket = "cg-keystore-s3-bucket-${var.cgid}"
+  bucket = "cg-keystore-s3-bucket-${local.bucket_suffix}"
   acl = "private"
   force_destroy = true
   tags = {
-    Name = "cg-keystore-s3-bucket-${var.cgid}"
+    Name = "cg-keystore-s3-bucket-${local.bucket_suffix}"
     Description = "CloudGoat ${var.cgid} S3 Bucket used for storing ssh keys"
     Stack = "${var.stack-name}"
     Scenario = "${var.scenario-name}"

--- a/scenarios/rce_web_app/terraform/s3.tf
+++ b/scenarios/rce_web_app/terraform/s3.tf
@@ -1,10 +1,3 @@
-locals {
-  # Ensure the bucket suffix doesn't contain invalid characters
-  # "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
-  # (per https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) 
-  bucket_suffix = replace(var.cgid, "/[^a-z0-9-.]/", "-")
-}
-
 #Logs S3 Bucket Policy
 resource "aws_s3_bucket_policy" "cg-logs-s3-bucket-policy" {
   bucket = "${aws_s3_bucket.cg-logs-s3-bucket.id}"
@@ -32,11 +25,11 @@ POLICY
 }
 #Logs S3 Bucket
 resource "aws_s3_bucket" "cg-logs-s3-bucket" {
-  bucket = "cg-logs-s3-bucket-${local.bucket_suffix}"
+  bucket = "cg-logs-s3-bucket-${local.cgid_suffix}"
   acl = "private"
   force_destroy = true
   tags = {
-      Name = "cg-logs-s3-bucket-${local.bucket_suffix}"
+      Name = "cg-logs-s3-bucket-${local.cgid_suffix}"
       Description = "CloudGoat ${var.cgid} S3 Bucket used for ALB Logs"
       Stack = "${var.stack-name}"
       Scenario = "${var.scenario-name}"
@@ -44,11 +37,11 @@ resource "aws_s3_bucket" "cg-logs-s3-bucket" {
 }
 #Secret S3 Bucket
 resource "aws_s3_bucket" "cg-secret-s3-bucket" {
-  bucket = "cg-secret-s3-bucket-${local.bucket_suffix}"
+  bucket = "cg-secret-s3-bucket-${local.cgid_suffix}"
   acl = "private"
   force_destroy = true
   tags = {
-      Name = "cg-secret-s3-bucket-${local.bucket_suffix}"
+      Name = "cg-secret-s3-bucket-${local.cgid_suffix}"
       Description = "CloudGoat ${var.cgid} S3 Bucket used for storing a secret"
       Stack = "${var.stack-name}"
       Scenario = "${var.scenario-name}"
@@ -56,11 +49,11 @@ resource "aws_s3_bucket" "cg-secret-s3-bucket" {
 }
 #Keystore S3 Bucket
 resource "aws_s3_bucket" "cg-keystore-s3-bucket" {
-  bucket = "cg-keystore-s3-bucket-${local.bucket_suffix}"
+  bucket = "cg-keystore-s3-bucket-${local.cgid_suffix}"
   acl = "private"
   force_destroy = true
   tags = {
-    Name = "cg-keystore-s3-bucket-${local.bucket_suffix}"
+    Name = "cg-keystore-s3-bucket-${local.cgid_suffix}"
     Description = "CloudGoat ${var.cgid} S3 Bucket used for storing ssh keys"
     Stack = "${var.stack-name}"
     Scenario = "${var.scenario-name}"


### PR DESCRIPTION
As described in #100, scenarios containing S3 buckets currently do not work because of an invalid underscore character in the S3 bucket names. This PR ensures that no such character exists and solves the issue