### PR TITLE
Reduce IAM permissions used in ec2_ssrf

### DIFF
--- a/scenarios/ec2_ssrf/terraform/iam.tf
+++ b/scenarios/ec2_ssrf/terraform/iam.tf
@@ -82,7 +82,11 @@ resource "aws_iam_policy" "cg-shepard-policy" {
         {
             "Sid": "shepard",
             "Effect": "Allow",
-            "Action": "*",
+            "Action": "Action": [
+                "lambda:Get*",
+                "lambda:Invoke*",
+                "lambda:List*"
+            ],
             "Resource": "*"
         }
     ]


### PR DESCRIPTION
The shephard user unnecessarily has full account access. It should only need to list/get/invoke lambda functions.


This change was suggested in #54.