### PR TITLE
Fix CGID naming for codebuild_secrets

### DIFF
--- a/scenarios/codebuild_secrets/terraform/rds.tf
+++ b/scenarios/codebuild_secrets/terraform/rds.tf
@@ -48,7 +48,7 @@ resource "aws_db_subnet_group" "cg-rds-testing-subnet-group" {
 }
 #RDS PostgreSQL Instance
 resource "aws_db_instance" "cg-psql-rds" {
-  identifier = "cg-rds-instance-${var.cgid}"
+  identifier = "cg-rds-instance-${local.cgid_suffix}"
   engine = "postgres"
   engine_version = "9.6"
   port = "5432"

--- a/scenarios/codebuild_secrets/terraform/variables.tf
+++ b/scenarios/codebuild_secrets/terraform/variables.tf
@@ -36,3 +36,10 @@ variable "stack-name" {
 variable "scenario-name" {
   default = "codebuild-secrets"
 }
+
+locals {
+  # Ensure the bucket suffix doesn't contain invalid characters
+  # "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-)."
+  # (per https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
+  cgid_suffix = replace(var.cgid, "/[^a-z0-9-.]/", "-")
+}


### PR DESCRIPTION
RDS DB's can't have underscores so ensure these are converted to dashes.