### PR TITLE
Fix broken IAM policy in ec2_ssrf scenario

### DIFF
--- a/scenarios/ec2_ssrf/terraform/iam.tf
+++ b/scenarios/ec2_ssrf/terraform/iam.tf
@@ -82,7 +82,7 @@ resource "aws_iam_policy" "cg-shepard-policy" {
         {
             "Sid": "shepard",
             "Effect": "Allow",
-            "Action": "Action": [
+            "Action": [
                 "lambda:Get*",
                 "lambda:Invoke*",
                 "lambda:List*"


### PR DESCRIPTION
This issue caused the EC2 SSRF scenario to be broken (tested on Terraform 0.14.x and 1.x). Introduced in 2b15402c8d35a267aa77c2d9d80c9952f4e706e6