### PR TITLE
Fix container build on non-arm64 hosts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM python:3.8-alpine
+FROM hashicorp/terraform:0.15.1
 
 LABEL maintainer="Rhino Assessment Team <cloudgoat@rhinosecuritylabs.com>"
 LABEL cloudgoat.version="2.0.0"
 
 RUN apk add --no-cache --update bash bash-completion docker-bash-completion openssh curl
 
-# Install Terraform and AWS CLI
-RUN wget -O terraform.zip 'https://releases.hashicorp.com/terraform/0.15.1/terraform_0.15.1_linux_arm64.zip' \
-    && unzip terraform.zip \
-    && rm terraform.zip \
-    && mv ./terraform /usr/bin/ \
-    && pip3 install awscli --upgrade
+# Install AWS CLI
+RUN apk update && apk add python3 py3-pip && \
+	pip3 install awscli --upgrade
 
 # Install CloudGoat
 WORKDIR /usr/src/cloudgoat/core/python
@@ -20,4 +17,5 @@ RUN pip3 install -r ./requirements.txt
 WORKDIR /usr/src/cloudgoat/
 COPY ./ ./
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["bash", "-l"]


### PR DESCRIPTION
This changes the Dockerfile to be based on the upstream docker container rather then pulling the executable down ourselves. Before we where accidentally fetching the arm64 version, which of course won't work on amd64 hosts.

I'm not positive, but I believe doing it this way is platform independent, if someone has a arm64 mac and can test this that would be appreciated. In any case this resolves the issue running the container on my amd host.

Resolves #122