### PR TITLE
detection_evasion: fixed filter pattern for instance profile usage

### DIFF
--- a/scenarios/detection_evasion/terraform/cloudwatch.tf
+++ b/scenarios/detection_evasion/terraform/cloudwatch.tf
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "honeytoken_alarm" {
 // resources for detecting/alerting on abnormal instance_profile usage
 resource "aws_cloudwatch_log_metric_filter" "instance_profile_abnormal_usage" {
   name           = "instance_profile_abnormal_usage"
-  pattern        = "{ (($.sourceIPAddress != \"${aws_instance.hard_path.private_ip}\") && ($.userIdentity.arn = \"arn:aws:sts::${data.aws_caller_identity.aws-account-id.account_id}:assumed-role/${aws_iam_role.ec2_instance_profile_role_hard_path.name}/${aws_instance.hard_path.id}\")) || (($.sourceIPAddress != \"${aws_instance.easy_path.public_ip}\") && ($.userIdentity.arn = \"arn:aws:sts::${data.aws_caller_identity.aws-account-id.account_id}:assumed-role/${aws_iam_role.ec2_instance_profile_role_hard_path.name}/${aws_instance.easy_path.id}\")) }"
+  pattern        = "{ (($.sourceIPAddress != \"${aws_instance.hard_path.private_ip}\") && ($.userIdentity.arn = \"arn:aws:sts::${data.aws_caller_identity.aws-account-id.account_id}:assumed-role/${aws_iam_role.ec2_instance_profile_role_hard_path.name}/${aws_instance.hard_path.id}\")) || (($.sourceIPAddress != \"${aws_instance.easy_path.public_ip}\") && ($.userIdentity.arn = \"arn:aws:sts::${data.aws_caller_identity.aws-account-id.account_id}:assumed-role/${aws_iam_role.ec2_instance_profile_role_easy_path.name}/${aws_instance.easy_path.id}\")) }"
   log_group_name = aws_cloudwatch_log_group.main.name
 
   metric_transformation {


### PR DESCRIPTION
There is a misconfiguration in the filter pattern for the instance_profile_abnormal_usage metric filter. The IP -> assumed role for the easy path is currently source_ip == easy_instance_ip && useridentity.arn == hard_path.name, which means that usage of the easy_path instance role outside of the instance will not trigger an alert. This PR adjusts the filter to source_ip == easy_instance_ip && useridentity.arn == easy_path.name.