### PR TITLE
Update commands.py create_scenario()

### DIFF
--- a/core/python/commands.py
+++ b/core/python/commands.py
@@ -453,9 +453,11 @@ class CloudGoat:
         with open(start_file_path, "w") as start_file:
             output = json.loads(output_stdout)
             for k, v in output.items():
-                l = f"{k} = {v['value']}"
-                print(l)
-                start_file.write(l + '\n')
+                # Check for the presence of 'sensitive-hidden' in the output description
+                if 'description' in v and 'sensitive-hidden' not in v['description']:
+                    l = f"{k} = {v['value']}"
+                    print(l)
+                    start_file.write(l + '\n')
 
         print(f"\n[cloudgoat] Output file written to:\n\n    {start_file_path}\n")
 


### PR DESCRIPTION
This commit modifies the behavior of CloudGoat to exclude outputs that contain 'sensitive-hidden' in their description from being printed to console or written to the 'start.txt' file. This change provides a useful option for scenarios that involve generating AWS keys during scenario execution but require those keys to be kept confidential and not disclosed in the console or output file.