### PR TITLE
Update ec2.tf

### DIFF
--- a/scenarios/ecs_takeover/terraform/ec2.tf
+++ b/scenarios/ecs_takeover/terraform/ec2.tf
@@ -1,9 +1,15 @@
 data "aws_ami" "ecs" {
-  owners = ["amazon"]
+  most_recent = true
+  owners      = ["amazon"]
 
   filter {
-    name   = "image-id"
-    values = ["ami-07fde2ae86109a2af"]
+    name   = "name"
+    values = ["amzn2-ami-ecs-hvm-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 


### PR DESCRIPTION
This update adds a dynamic AMI ID to the ec2.tf for the ecs_takeover scenario.

Fixes #191.