### PR TITLE
Update s3.tf

### DIFF
--- a/scenarios/ec2_ssrf/terraform/s3.tf
+++ b/scenarios/ec2_ssrf/terraform/s3.tf
@@ -16,7 +16,8 @@ resource "aws_s3_bucket" "cg-secret-s3-bucket" {
       Scenario = "${var.scenario-name}"
   }
 }
-resource "aws_s3_bucket_object" "cg-shepards-credentials" {
+
+resource "aws_s3_object" "cg-shepards-credentials" {
   bucket = "${aws_s3_bucket.cg-secret-s3-bucket.id}"
   key = "admin-user.txt"
   source = "../assets/admin-user.txt"
@@ -25,9 +26,4 @@ resource "aws_s3_bucket_object" "cg-shepards-credentials" {
     Stack = "${var.stack-name}"
     Scenario = "${var.scenario-name}"
   }
-}
-
-resource "aws_s3_bucket_acl" "secret-s3-bucket-acl" {
-  bucket = aws_s3_bucket.cg-secret-s3-bucket.id
-  acl    = "private"
 }


### PR DESCRIPTION
Fixes #188 

[Buckets are set to private by default now since April 27th, 2023.](https://aws.amazon.com/blogs/aws/amazon-s3-block-public-access-another-layer-of-protection-for-your-accounts-and-buckets/)

It looks like the aws_s3_bucket_acl resource is attempting to set the bucket's ACL to private, but this operation is being blocked because ACLs are not supported for the bucket.

ACLs are now considered legacy access control, with bucket policies and IAM policies being the recommended way to manage access to S3 buckets.

Simply removing the ACL resource solves the issue.