### PR TITLE
Fix Typo in README.md

### DIFF
--- a/scenarios/vulnerable_lambda/README.md
+++ b/scenarios/vulnerable_lambda/README.md
@@ -25,7 +25,7 @@ Find the scenario's secret. (cg-secret-XXXXXX-XXXXXX)
 
 In this scenario, you start as the 'bilbo' user. You will assume a role with more privileges, discover a 
 lambda function that applies policies to users, and exploit a vulnerability in the function to escalate 
-the prrivileges of the bilbo user in order to search for secrets. 
+the privileges of the bilbo user in order to search for secrets. 
 
 ## Exploitation Route
 


### PR DESCRIPTION
Fix Typo in `README.md` on `vulnerable_lambda` scenario.