### PR TITLE
Update Vulnerable Cognito

### DIFF
--- a/scenarios/vulnerable_cognito/cheat_sheet.md
+++ b/scenarios/vulnerable_cognito/cheat_sheet.md
@@ -5,3 +5,7 @@
 `aws cognito-idp get-user --access-token [AccessToken]`
 
 `aws cognito-idp update-user-attributes --access-token [AccessToken] --user-attributes '[{"Name":"custom:access","Value":"admin"}]'`
+
+`aws cognito-identity get-id --region [region] --identity-pool-id '[IdentityPool_Id]' --logins "cognito-idp.{region}.amazonaws.com/{UserPoolId}={idToken}"`
+
+`aws cognito-identity get-credentials-for-identity --region [region] --identity-id '[Id-found]' --logins "cognito-idp.{region}.amazonaws.com/{UserPoolId}={idToken}"`

--- a/scenarios/vulnerable_cognito/manifest.yml
+++ b/scenarios/vulnerable_cognito/manifest.yml
@@ -4,11 +4,11 @@
   # The name of the author(s), comma separated
 - author: Usama Azad
   # The version of the scenario, where major versions are breaking changes and minor are small fixes.
-- version: 1.0
+- version: 1.1
   # Text displayed to the user when they type "{{ scenario_name }} help"
 - help: |
         In this scenario, you are presented with a Signup and login page with AWS Cognito in the backend. You need to bypass restrictions and exploit misconfigurations in Amazon Cognito in order to elevate your privileges and get Cognito Identity Pool credentials.
 
 # Records the date upon which this scenario was last updated, in MM-DD-YYYY format
-- last-updated: 02-16-2023
+- last-updated: 08-28-2023
 ...

--- a/scenarios/vulnerable_cognito/terraform/apig.tf
+++ b/scenarios/vulnerable_cognito/terraform/apig.tf
@@ -1,37 +1,20 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.16"
-    }
-  }
-
-  required_version = ">= 1.2.0"
-}
-
-
-
-
-
-
-
 # Create S3 Full Access Policy
 resource "aws_iam_policy" "s3_policy" {
   name        = "s3-policy${var.cgid}"
   description = "Policy for allowing all S3 Actions"
 
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
+  policy = jsonencode(
+    {
+      Version = "2012-10-17"
+      Statement = [
         {
-            "Effect": "Allow",
-            "Action": "s3:Get*",
-            "Resource": "${aws_s3_bucket.cognito_s3.arn}/*"
+          Effect   = "Allow"
+          Action   = "s3:Get*"
+          Resource = "${aws_s3_bucket.cognito_s3.arn}/*"
         }
-    ]
-}
-EOF
+      ]
+    }
+  )
 }
 
 # Create API Gateway Role
@@ -39,27 +22,27 @@ resource "aws_iam_role" "s3_api_gateyway_role" {
   name = "s3-api-gateyway-role-${var.cgid}"
 
   # Create Trust Policy for API Gateway
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  assume_role_policy = jsonencode(
     {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "apigateway.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Sid    = ""
+          Effect = "Allow"
+          Principal = {
+            Service = "apigateway.amazonaws.com"
+          }
+          Action = "sts:AssumeRole"
+        }
+      ]
     }
-  ]
-} 
-  EOF
+  )
 }
 
 # Attach S3 Access Policy to the API Gateway Role
 resource "aws_iam_role_policy_attachment" "s3_policy_attach" {
-  role       = "${aws_iam_role.s3_api_gateyway_role.name}"
-  policy_arn = "${aws_iam_policy.s3_policy.arn}"
+  role       = aws_iam_role.s3_api_gateyway_role.name
+  policy_arn = aws_iam_policy.s3_policy.arn
 }
 
 resource "aws_api_gateway_rest_api" "MyS3" {
@@ -68,27 +51,27 @@ resource "aws_api_gateway_rest_api" "MyS3" {
 }
 
 resource "aws_api_gateway_resource" "Folder" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  parent_id   = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  parent_id   = aws_api_gateway_rest_api.MyS3.root_resource_id
   path_part   = "{folder}"
 }
 
 resource "aws_api_gateway_resource" "Item" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  parent_id   = "${aws_api_gateway_resource.Folder.id}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  parent_id   = aws_api_gateway_resource.Folder.id
   path_part   = "{item}"
 }
 
 resource "aws_api_gateway_method" "GetBuckets" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id   = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyS3.id
+  resource_id   = aws_api_gateway_rest_api.MyS3.root_resource_id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_method" "GetBucketFolder" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id   = "${aws_api_gateway_resource.Folder.id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyS3.id
+  resource_id   = aws_api_gateway_resource.Folder.id
   http_method   = "GET"
   authorization = "NONE"
   request_parameters = {
@@ -97,22 +80,20 @@ resource "aws_api_gateway_method" "GetBucketFolder" {
 }
 
 resource "aws_api_gateway_method" "GetBucketItem" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id   = "${aws_api_gateway_resource.Item.id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyS3.id
+  resource_id   = aws_api_gateway_resource.Item.id
   http_method   = "GET"
   authorization = "NONE"
   request_parameters = {
-    "method.request.path.item" = true
+    "method.request.path.item"   = true
     "method.request.path.folder" = true
   }
 }
 
-
-
 resource "aws_api_gateway_integration" "S3Integration" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
 
   # Included because of this issue: https://github.com/hashicorp/terraform/issues/10501
   integration_http_method = "GET"
@@ -121,13 +102,13 @@ resource "aws_api_gateway_integration" "S3Integration" {
 
   # See uri description: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
   uri         = "arn:aws:apigateway:${var.region}:s3:path//"
-  credentials = "${aws_iam_role.s3_api_gateyway_role.arn}"
+  credentials = aws_iam_role.s3_api_gateyway_role.arn
 }
 
 resource "aws_api_gateway_integration" "S3FolderIntegration" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_resource.Folder.id}"
-  http_method = "${aws_api_gateway_method.GetBucketFolder.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_resource.Folder.id
+  http_method = aws_api_gateway_method.GetBucketFolder.http_method
 
   # Included because of this issue: https://github.com/hashicorp/terraform/issues/10501
   integration_http_method = "GET"
@@ -136,20 +117,20 @@ resource "aws_api_gateway_integration" "S3FolderIntegration" {
 
   # See uri description: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
   uri         = "arn:aws:apigateway:${var.region}:s3:path/{bucket}"
-  credentials = "${aws_iam_role.s3_api_gateyway_role.arn}"
+  credentials = aws_iam_role.s3_api_gateyway_role.arn
 
   request_parameters = {
-        "integration.request.path.bucket" = "method.request.path.folder"
-    }
+    "integration.request.path.bucket" = "method.request.path.folder"
+  }
 
-  passthrough_behavior    = "WHEN_NO_MATCH"
+  passthrough_behavior = "WHEN_NO_MATCH"
 
 }
 
 resource "aws_api_gateway_integration" "S3ItemIntegration" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_resource.Item.id}"
-  http_method = "${aws_api_gateway_method.GetBucketItem.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_resource.Item.id
+  http_method = aws_api_gateway_method.GetBucketItem.http_method
 
   # Included because of this issue: https://github.com/hashicorp/terraform/issues/10501
   integration_http_method = "GET"
@@ -158,19 +139,19 @@ resource "aws_api_gateway_integration" "S3ItemIntegration" {
 
   # See uri description: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
   uri         = "arn:aws:apigateway:${var.region}:s3:path/{bucket}/{object}"
-  credentials = "${aws_iam_role.s3_api_gateyway_role.arn}"
+  credentials = aws_iam_role.s3_api_gateyway_role.arn
   request_parameters = {
-        "integration.request.path.bucket" = "method.request.path.folder"
-        "integration.request.path.object" = "method.request.path.item"
-    }
+    "integration.request.path.bucket" = "method.request.path.folder"
+    "integration.request.path.object" = "method.request.path.item"
+  }
 
-  passthrough_behavior    = "WHEN_NO_MATCH"
+  passthrough_behavior = "WHEN_NO_MATCH"
 }
 
 resource "aws_api_gateway_method_response" "two00" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
   status_code = "200"
 
   response_parameters = {
@@ -178,37 +159,33 @@ resource "aws_api_gateway_method_response" "two00" {
     "method.response.header.Content-Length" = true
     "method.response.header.Content-Type"   = true
   }
-
-#  response_models = {
-#    "application/json" = "Empty"
-#  }
 }
 
 resource "aws_api_gateway_method_response" "four00" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
   status_code = "400"
 }
 
 resource "aws_api_gateway_method_response" "five00" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
   status_code = "500"
 }
 
 resource "aws_api_gateway_integration_response" "two00IntegrationResponse" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
-  status_code = "${aws_api_gateway_method_response.two00.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
+  status_code = aws_api_gateway_method_response.two00.status_code
 
   response_parameters = {
     "method.response.header.Timestamp"      = "integration.response.header.Date"
@@ -217,30 +194,25 @@ resource "aws_api_gateway_integration_response" "two00IntegrationResponse" {
   }
 }
 
-
 resource "aws_api_gateway_method_response" "two00Folder" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id   = "${aws_api_gateway_resource.Folder.id}"
-  http_method   = "${aws_api_gateway_method.GetBucketFolder.http_method}"
-  status_code   = "200"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_resource.Folder.id
+  http_method = aws_api_gateway_method.GetBucketFolder.http_method
+  status_code = "200"
 
   response_parameters = {
     "method.response.header.Timestamp"      = true
     "method.response.header.Content-Length" = true
     "method.response.header.Content-Type"   = true
   }
-
-#  response_models = {
-#    "application/json" = "Empty"
-#  }
 }
 
 resource "aws_api_gateway_integration_response" "two00FolderIntegrationResponse" {
-  depends_on = ["aws_api_gateway_integration.S3FolderIntegration"]
-  rest_api_id   = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id   = "${aws_api_gateway_resource.Folder.id}"
-  http_method   = "${aws_api_gateway_method.GetBucketFolder.http_method}"
-  status_code = "${aws_api_gateway_method_response.two00Folder.status_code}"
+  depends_on  = [aws_api_gateway_integration.S3FolderIntegration]
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_resource.Folder.id
+  http_method = aws_api_gateway_method.GetBucketFolder.http_method
+  status_code = aws_api_gateway_method_response.two00Folder.status_code
 
   response_parameters = {
     "method.response.header.Timestamp"      = "integration.response.header.Date"
@@ -249,69 +221,55 @@ resource "aws_api_gateway_integration_response" "two00FolderIntegrationResponse"
   }
 }
 
-
-
 resource "aws_api_gateway_method_response" "two00Item" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_resource.Item.id}"
-  http_method = "${aws_api_gateway_method.GetBucketItem.http_method}"
-  status_code   = "200"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_resource.Item.id
+  http_method = aws_api_gateway_method.GetBucketItem.http_method
+  status_code = "200"
 
   response_parameters = {
-#    "method.response.header.Timestamp"      = true
-#    "method.response.header.Content-Length" = true
-    "method.response.header.Content-Type"   = true
+    "method.response.header.Content-Type" = true
   }
-
-#  response_models = {
-#    "application/json" = "Empty"
-#  }
 }
 
 resource "aws_api_gateway_integration_response" "two00ItemIntegrationResponse" {
-  depends_on = ["aws_api_gateway_integration.S3ItemIntegration"]
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_resource.Item.id}"
-  http_method = "${aws_api_gateway_method.GetBucketItem.http_method}"
-  status_code = "${aws_api_gateway_method_response.two00Item.status_code}"
+  depends_on  = [aws_api_gateway_integration.S3ItemIntegration]
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_resource.Item.id
+  http_method = aws_api_gateway_method.GetBucketItem.http_method
+  status_code = aws_api_gateway_method_response.two00Item.status_code
 
   response_parameters = {
-#    "method.response.header.Timestamp"      = "integration.response.header.Date"
-#    "method.response.header.Content-Length" = "integration.response.header.Content-Length"
-    "method.response.header.Content-Type"   = "integration.response.header.Content-Type"
+    "method.response.header.Content-Type" = "integration.response.header.Content-Type"
   }
 }
 
-
-
 resource "aws_api_gateway_integration_response" "four00IntegrationResponse" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
-  status_code = "${aws_api_gateway_method_response.four00.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
+  status_code = aws_api_gateway_method_response.four00.status_code
 
   selection_pattern = "4\\d{2}"
 }
 
 resource "aws_api_gateway_integration_response" "five00IntegrationResponse" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
-  status_code = "${aws_api_gateway_method_response.five00.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
+  status_code = aws_api_gateway_method_response.five00.status_code
 
   selection_pattern = "5\\d{2}"
 }
 
 resource "aws_api_gateway_deployment" "S3APIDeployment" {
-  depends_on  = ["aws_api_gateway_integration.S3Integration","aws_api_gateway_integration.S3FolderIntegration","aws_api_gateway_integration.S3ItemIntegration"]
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-#  stage_name  = "vulncognito"
+  depends_on  = [aws_api_gateway_integration.S3Integration, aws_api_gateway_integration.S3FolderIntegration, aws_api_gateway_integration.S3ItemIntegration]
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
 }
-
 
 resource "aws_api_gateway_stage" "S3APIStage" {
   deployment_id = aws_api_gateway_deployment.S3APIDeployment.id
@@ -320,23 +278,21 @@ resource "aws_api_gateway_stage" "S3APIStage" {
 }
 
 resource "aws_api_gateway_rest_api_policy" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  policy = jsonencode(
     {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": "execute-api:Invoke",
-      "Resource": "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.aws-account-id.account_id}:${aws_api_gateway_rest_api.MyS3.id}/*"
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Principal = {
+            AWS = "*"
+          }
+          Action   = "execute-api:Invoke"
+          Resource = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.aws-account-id.account_id}:${aws_api_gateway_rest_api.MyS3.id}/*"
+        }
+      ]
     }
-  ]
+  )
 }
-EOF
-}
-
-

--- a/scenarios/vulnerable_cognito/terraform/cognito.tf
+++ b/scenarios/vulnerable_cognito/terraform/cognito.tf
@@ -1,12 +1,12 @@
 resource "aws_cognito_user_pool" "ctf_pool" {
-  name               = "CognitoCTF-${var.cgid}"
+  name = "CognitoCTF-${var.cgid}"
   account_recovery_setting {
     recovery_mechanism {
-        name     = "verified_email"
-        priority = 1
-      }
+      name     = "verified_email"
+      priority = 1
+    }
   }
-  
+
   lambda_config {
     post_confirmation = aws_lambda_function.test_lambda.arn
   }
@@ -26,38 +26,37 @@ resource "aws_cognito_user_pool" "ctf_pool" {
   }
 
   schema {
-      name         = "access"
-      mutable      = true
-      attribute_data_type = "String"
-}
+    name                = "access"
+    mutable             = true
+    attribute_data_type = "String"
+  }
 
-schema {
-      name         = "email"
-      required     = true
-      attribute_data_type = "String"
-}
+  schema {
+    name                = "email"
+    required            = true
+    attribute_data_type = "String"
+  }
 
-schema {
-      name         = "given_name"
-      required     = true
-      attribute_data_type = "String"
-}
-    
-schema {
-      name         = "family_name"
-      required     = true
-      attribute_data_type = "String"
-}
+  schema {
+    name                = "given_name"
+    required            = true
+    attribute_data_type = "String"
+  }
 
+  schema {
+    name                = "family_name"
+    required            = true
+    attribute_data_type = "String"
+  }
 
   password_policy {
-      minimum_length            = 8
-      require_uppercase         = true
-      require_lowercase         = true
-      require_numbers           = true
-      require_symbols           = true
-      temporary_password_validity_days = 7
-    }
+    minimum_length                   = 8
+    require_uppercase                = true
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    temporary_password_validity_days = 7
+  }
 
   username_attributes = ["email"]
 
@@ -68,35 +67,29 @@ schema {
   mfa_configuration = "OFF"
 }
 
-/*resource "aws_cognito_user_pool_domain" "cgnito-domain" {
-  domain       = "d${local.suffix}"
-  user_pool_id = aws_cognito_user_pool.ctf_pool.id
-}*/
-
-
 resource "aws_cognito_user_pool_client" "cognito_client" {
-  explicit_auth_flows = ["ALLOW_REFRESH_TOKEN_AUTH","ALLOW_CUSTOM_AUTH","ALLOW_USER_SRP_AUTH","ALLOW_USER_PASSWORD_AUTH"]
-  auth_session_validity = 3
+  explicit_auth_flows    = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_CUSTOM_AUTH", "ALLOW_USER_SRP_AUTH", "ALLOW_USER_PASSWORD_AUTH"]
+  auth_session_validity  = 3
   refresh_token_validity = 30
-  access_token_validity = 60
-  id_token_validity = 60
+  access_token_validity  = 60
+  id_token_validity      = 60
   token_validity_units {
     refresh_token = "days"
-    access_token = "minutes"
-    id_token = "minutes"
+    access_token  = "minutes"
+    id_token      = "minutes"
   }
-  enable_token_revocation = true
-  prevent_user_existence_errors = "ENABLED"
-  allowed_oauth_flows = ["code"]
-  allowed_oauth_scopes = ["openid","phone","email"]
-  supported_identity_providers = ["COGNITO"]
-  callback_urls = ["https://example.com/"]
+  enable_token_revocation              = true
+  prevent_user_existence_errors        = "ENABLED"
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_scopes                 = ["openid", "phone", "email"]
+  supported_identity_providers         = ["COGNITO"]
+  callback_urls                        = ["https://example.com/"]
   allowed_oauth_flows_user_pool_client = true
-  name = "CognitoClient-${var.cgid}"
-  user_pool_id = aws_cognito_user_pool.ctf_pool.id
-  generate_secret = false
-  read_attributes = ["address","birthdate","custom:access","email","email_verified","family_name","gender","given_name","locale","middle_name","name","nickname","phone_number","phone_number_verified","picture","preferred_username","profile","updated_at","website","zoneinfo"]
-  write_attributes = ["address","birthdate","custom:access","email","family_name","gender","given_name","locale","middle_name","name","nickname","phone_number","picture","preferred_username","profile","updated_at","website","zoneinfo"]
+  name                                 = "CognitoClient-${var.cgid}"
+  user_pool_id                         = aws_cognito_user_pool.ctf_pool.id
+  generate_secret                      = false
+  read_attributes                      = ["address", "birthdate", "custom:access", "email", "email_verified", "family_name", "gender", "given_name", "locale", "middle_name", "name", "nickname", "phone_number", "phone_number_verified", "picture", "preferred_username", "profile", "updated_at", "website", "zoneinfo"]
+  write_attributes                     = ["address", "birthdate", "custom:access", "email", "family_name", "gender", "given_name", "locale", "middle_name", "name", "nickname", "phone_number", "picture", "preferred_username", "profile", "updated_at", "website", "zoneinfo"]
 }
 
 resource "aws_cognito_identity_pool" "main" {
@@ -112,57 +105,54 @@ resource "aws_cognito_identity_pool" "main" {
 
 }
 
-
 resource "aws_iam_role" "authenticated" {
   name = "cognito_authenticated-${var.cgid}"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  assume_role_policy = jsonencode(
     {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "cognito-identity.amazonaws.com"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringEquals": {
-          "cognito-identity.amazonaws.com:aud": "${aws_cognito_identity_pool.main.id}"
-        },
-        "ForAnyValue:StringLike": {
-          "cognito-identity.amazonaws.com:amr": "authenticated"
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Principal = {
+            Federated = "cognito-identity.amazonaws.com"
+          },
+          Action = "sts:AssumeRoleWithWebIdentity"
+          Condition = {
+            StringEquals = {
+              "cognito-identity.amazonaws.com:aud" = aws_cognito_identity_pool.main.id
+            }
+            "ForAnyValue:StringLike" = {
+              "cognito-identity.amazonaws.com:amr" = "authenticated"
+            }
+          }
         }
-      }
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "authenticated" {
-  name = "authenticated_policy-${var.cgid}"
-  role = aws_iam_role.authenticated.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:*",
-        "cognitoidp:*",
-        "cognito-identity:*",
-        "lambda:*"
-      ],
-      "Resource": [
-        "*"
       ]
     }
-  ]
-}
-EOF
+  )
+
+  inline_policy {
+    name = "authenticated_policy-${var.cgid}"
+    policy = jsonencode(
+      {
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Effect = "Allow",
+            Action = [
+              "s3:*",
+              "cognitoidp:*",
+              "cognito-identity:*",
+              "lambda:*"
+            ]
+            Resource = [
+              "*"
+            ]
+          }
+        ]
+      }
+    )
+  }
 }
 
 resource "aws_cognito_identity_pool_roles_attachment" "main" {

--- a/scenarios/vulnerable_cognito/terraform/data_sources.tf
+++ b/scenarios/vulnerable_cognito/terraform/data_sources.tf
@@ -1,3 +1,1 @@
-data "aws_caller_identity" "aws-account-id" {
-  
-}
+data "aws_caller_identity" "aws-account-id" {}

--- a/scenarios/vulnerable_cognito/terraform/lambda.tf
+++ b/scenarios/vulnerable_cognito/terraform/lambda.tf
@@ -1,21 +1,25 @@
 resource "aws_iam_role" "iam_for_lambda" {
   name = "iam_for_lambda-${var.cgid}"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  assume_role_policy = jsonencode(
     {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = "sts:AssumeRole"
+          Principal = {
+            Service = "lambda.amazonaws.com"
+          }
+          Effect = "Allow"
+          Sid    = ""
+        }
+      ]
     }
+  )
+
+  managed_policy_arns = [
+    aws_iam_policy.cognito-policy.arn
   ]
-}
-EOF
 }
 
 resource "aws_iam_policy" "cognito-policy" {
@@ -23,27 +27,21 @@ resource "aws_iam_policy" "cognito-policy" {
   path        = "/"
   description = "IAM policy for logging from a lambda"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+  policy = jsonencode(
     {
-      "Action": [
-        "cognito-idp:*"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "cognito-idp:*"
+          ]
+          Resource = "*"
+          Effect   = "Allow"
+        }
+      ]
     }
-  ]
+  )
 }
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "lambda-role" {
-  role       = aws_iam_role.iam_for_lambda.name
-  policy_arn = aws_iam_policy.cognito-policy.arn
-}
-
 
 resource "aws_lambda_function" "test_lambda" {
   # If the file is not in the current working directory you will need to include a
@@ -53,20 +51,10 @@ resource "aws_lambda_function" "test_lambda" {
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "lambda_function.lambda_handler"
 
-  # The filebase64sha256() function is available in Terraform 0.11.12 and later
-  # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
-  # source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
   source_code_hash = filebase64sha256("../assets/cognito-lambda.zip")
 
   runtime = "python3.9"
-
-  environment {
-    variables = {
-      foo = "bar"
-    }
-  }
 }
-
 
 resource "aws_lambda_permission" "allow_cognitoidp" {
   statement_id  = "AllowExecutionFromCognitoIDP"
@@ -74,4 +62,3 @@ resource "aws_lambda_permission" "allow_cognitoidp" {
   function_name = aws_lambda_function.test_lambda.function_name
   principal     = "cognito-idp.amazonaws.com"
 }
-

--- a/scenarios/vulnerable_cognito/terraform/outputs.tf
+++ b/scenarios/vulnerable_cognito/terraform/outputs.tf
@@ -1,9 +1,7 @@
 output "cloudgoat_output_aws_account_id" {
-  value = "${data.aws_caller_identity.aws-account-id.account_id}"
+  value = data.aws_caller_identity.aws-account-id.account_id
 }
 
 output "apigateway_url" {
   value = "https://${aws_api_gateway_rest_api.MyS3.id}.execute-api.${var.region}.amazonaws.com/vulncognito/${aws_s3_bucket.cognito_s3.id}/index.html"
 }
-
-

--- a/scenarios/vulnerable_cognito/terraform/provider.tf
+++ b/scenarios/vulnerable_cognito/terraform/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  profile = "${var.profile}"
-  region = "${var.region}"
+  profile = var.profile
+  region  = var.region
 }

--- a/scenarios/vulnerable_cognito/terraform/s3.tf
+++ b/scenarios/vulnerable_cognito/terraform/s3.tf
@@ -1,40 +1,4 @@
 locals {
-  suffix = replace(var.cgid, "/[^a-z0-9]/", "")
-}
-
-
-resource "aws_s3_bucket" "cognito_s3" {
-  bucket = "cognitoctf-${local.suffix}"
-  force_destroy = true
-}
-
-
-
-resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
-  bucket = aws_s3_bucket.cognito_s3.id
-  policy = data.aws_iam_policy_document.allow_access_from_another_account.json
-}
-
-
-data "aws_iam_policy_document" "allow_access_from_another_account" {
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    actions = [
-      "s3:Get*",
-    ]
-
-    resources = [
-      aws_s3_bucket.cognito_s3.arn,
-      "${aws_s3_bucket.cognito_s3.arn}/*",
-    ]
-  }
-}
-
-locals {
   mime_types = {
     "css"  = "text/css"
     "html" = "text/html"
@@ -48,43 +12,70 @@ locals {
   }
 }
 
-resource "aws_s3_bucket_object" "dist" {
+
+resource "aws_s3_bucket" "cognito_s3" {
+  bucket        = "cognitoctf-${replace(var.cgid, "/[^a-z0-9]/", "")}"
+  force_destroy = true
+}
+
+# AWS will block the bucket policy unless access is granted
+resource "aws_s3_bucket_public_access_block" "cognito_s3" {
+  bucket = aws_s3_bucket.cognito_s3.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
+  depends_on = [aws_s3_bucket_public_access_block.cognito_s3]
+
+  bucket = aws_s3_bucket.cognito_s3.id
+  policy = jsonencode(
+    {
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Sid    = ""
+          Effect = "Allow"
+          Principal = {
+            AWS = "*"
+          },
+          Action = "s3:Get*"
+          Resource = [
+            "${aws_s3_bucket.cognito_s3.arn}/*",
+            aws_s3_bucket.cognito_s3.arn
+          ]
+        }
+      ]
+    }
+  )
+}
+
+resource "aws_s3_object" "dist" {
   for_each = fileset("../assets/app/static/", "*")
 
-  bucket = aws_s3_bucket.cognito_s3.id
-  key    = each.value
-  source = "../assets/app/static/${each.value}"
+  bucket       = aws_s3_bucket.cognito_s3.id
+  key          = each.value
+  source       = "../assets/app/static/${each.value}"
   content_type = lookup(tomap(local.mime_types), element(split(".", each.key), length(split(".", each.key)) - 1))
-  etag   = filemd5("../assets/app/static/${each.value}")
+  source_hash  = filemd5("../assets/app/static/${each.value}")
 }
 
-
-
-resource "aws_s3_bucket_object" "html" {
+resource "aws_s3_object" "html" {
   for_each = fileset("../assets/app/", "*")
 
-  bucket = aws_s3_bucket.cognito_s3.id
-  key    = each.value
-  #source = "../assets/app/${each.value}"
-  content  = data.template_file.data[each.value].rendered
+  bucket       = aws_s3_bucket.cognito_s3.id
+  key          = each.value
   content_type = lookup(tomap(local.mime_types), element(split(".", each.key), length(split(".", each.key)) - 1))
-  etag   = filemd5("../assets/app/${each.value}")
-}
+  source_hash  = filemd5("../assets/app/${each.value}")
 
-
-data "template_file" "data" {
-  for_each = fileset("../assets/app", "*")
-  template = file("../assets/app/${each.value}")
-
-  vars = {
-    cognito_userpool_id = aws_cognito_user_pool.ctf_pool.id
+  content = templatefile("../assets/app/${each.value}", {
+    cognito_userpool_id  = aws_cognito_user_pool.ctf_pool.id
     cognito_userpool_uri = "cognito-idp.${var.region}.amazonaws.com/${aws_cognito_user_pool.ctf_pool.id}"
-    cognito_identity_id = aws_cognito_identity_pool.main.id
-    cognito_client_id = aws_cognito_user_pool_client.cognito_client.id
-    region_html = var.region
-  }
-
+    cognito_identity_id  = aws_cognito_identity_pool.main.id
+    cognito_client_id    = aws_cognito_user_pool_client.cognito_client.id
+    region_html          = var.region
+  })
 }
-
-
-

--- a/scenarios/vulnerable_cognito/terraform/variables.tf
+++ b/scenarios/vulnerable_cognito/terraform/variables.tf
@@ -1,27 +1,32 @@
 variable "profile" {
   description = "The AWS profile to use."
+  type        = string
 }
 
 variable "region" {
   description = "The AWS region to deploy resources to."
-  default = "us-east-1"
+  default     = "us-east-1"
+  type        = string
 }
 
 variable "cgid" {
   description = "CGID variable for unique naming."
+  type        = string
 }
 
 variable "cg_whitelist" {
   description = "User's public IP address(es)."
-  type = list(string)
+  type        = list(string)
 }
 
 variable "stack-name" {
   description = "Name of the stack."
-  default = "CloudGoat"
+  default     = "CloudGoat"
+  type        = string
 }
 
 variable "scenario-name" {
   description = "Name of the scenario."
-  default = "vulnerable_cognito"
+  default     = "vulnerable_cognito"
+  type        = string
 }

--- a/scenarios/vulnerable_cognito/terraform/versions.tf
+++ b/scenarios/vulnerable_cognito/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}


### PR DESCRIPTION
#### Overview of Changes
##### Major Changes
- Pulling in additional cheat sheet steps from https://github.com/RhinoSecurityLabs/cloudgoat/pull/204
- Deprecated resource `aws_s3_bucket_object-> aws_s3_object`
- Remove `template_file` data call, switched to `templatefile()` function
- Add `aws_s3_bucket_public_access_block` resource to allow the bucket policy (https://github.com/RhinoSecurityLabs/cloudgoat/issues/187)

##### Minor Changes
- Formatting of Terraform code (`terraform fmt`)
- Linting (used [tflint](https://github.com/terraform-linters/tflint))
- Switched from json blobs to Terraform `jsonencode`
- Move inline policies directly onto the role
- Remove unused commented out Terraform

#### Testing
Run thought the scenario in Terraform versions `1.2.0` & `1.5.6` (latest)
