### PR TITLE
Fixing Issues with ECR Removal & SSM Connectivity

### DIFF
--- a/scenarios/cicd/terraform/dev_machine.tf
+++ b/scenarios/cicd/terraform/dev_machine.tf
@@ -54,11 +54,34 @@ resource "aws_instance" "dev" {
   instance_type        = "t3.micro"
   iam_instance_profile = aws_iam_instance_profile.dev.name
   user_data            = templatefile("${path.module}/../assets/dev-machine/provision.sh", { private_ssh_key = tls_private_key.ssh_key.private_key_pem })
-  subnet_id = module.vpc.private_subnets[0]
+  subnet_id            = module.vpc.private_subnets[0]
+
+  security_groups = [
+    aws_security_group.allow_egress.id
+  ]
 
   tags = {
     Name        = "dev-instance",
     Environment = "dev"
+  }
+}
+
+resource "aws_security_group" "allow_egress" {
+  name        = "allow_egress"
+  description = "Allow server to communicate with AWS SSM"
+  vpc_id      = module.vpc.vpc_id
+
+  egress {
+    description      = "Allow communication between session manager and the server"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name = "cicd_allow_egress"
   }
 }
 

--- a/scenarios/cicd/terraform/sdlc.tf
+++ b/scenarios/cicd/terraform/sdlc.tf
@@ -56,5 +56,6 @@ BASH
 resource "aws_ecr_repository" "app" {
   name                 = local.ecr_repository_name
   image_tag_mutability = "MUTABLE"
+  force_delete         = true
 }
 


### PR DESCRIPTION
#### Overview of Changes
- ECR repository will be deleted even with images
  - https://github.com/RhinoSecurityLabs/cloudgoat/issues/200
- Add egress security group on EC2 instance to allow communication with SSM
  - https://github.com/RhinoSecurityLabs/cloudgoat/issues/212
  - https://github.com/RhinoSecurityLabs/cloudgoat/issues/200

#### Testing
- Verify SSM works by default
- ECR removes with images