### PR TITLE
Fix Detection Evasion Scenario

### DIFF
--- a/scenarios/detection_evasion/README.md
+++ b/scenarios/detection_evasion/README.md
@@ -8,13 +8,14 @@
 
 ## Scenario Resources (High Level)
 
-4 IAM Users
-
-2 EC2 instances
-
-2 SecretsManager secrets
-
-A suite of detection mechanisms
+- 4 IAM Users
+- 2 EC2 instances
+- 2 SecretsManager secrets
+- A suite of detection mechanisms
+  - CloudTrail
+  - S3
+  - CloudWatch
+  - SNS
 
 ## Scenario Start(s)
 

--- a/scenarios/detection_evasion/cheat_sheet.md
+++ b/scenarios/detection_evasion/cheat_sheet.md
@@ -104,7 +104,7 @@ after you have retrieved the credentials from IMDS.
     ```
 
 6. There is a way to spoof arbitrary IP addresses in CloudTrail, and you can read about it
-   in [this blog post](https://www.hunters.ai/blog/hunters-research-detecting-obfuscated-attacker-ip-in-aws). Instead of
+   in [this blog post](https://www.hunters.security/en/blog/hunters-research-detecting-obfuscated-attacker-ip-in-aws). Instead of
    walking through this entire technique in duplicate here, we have created a public github repo with terraform code
    that will deploy the necessary resources to perform the bypass.
 

--- a/scenarios/detection_evasion/terraform/cloudtrail.tf
+++ b/scenarios/detection_evasion/terraform/cloudtrail.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "cloudtrail_role_inline_policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:${data.aws_caller_identity.aws-account-id.account_id}:log-group:${aws_cloudwatch_log_group.main.name}:log-stream:*",]
+    resources = ["arn:aws:logs:*:${data.aws_caller_identity.aws-account-id.account_id}:log-group:${aws_cloudwatch_log_group.main.name}:log-stream:*", ]
   }
 }
 
@@ -36,14 +36,14 @@ resource "aws_cloudtrail" "cloudgoat_trail" {
   s3_bucket_name                = aws_s3_bucket.cloudtrail_logs.id
   s3_key_prefix                 = "prefix"
   include_global_service_events = true
-  is_multi_region_trail = true
+  is_multi_region_trail         = true
   event_selector {
     read_write_type           = "All"
     include_management_events = true
   }
   // CloudTrail requires the Log Stream wildcard for the parameter below
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.main.arn}:*"
-  cloud_watch_logs_role_arn = aws_iam_role.cloudtrail_role.arn
+  cloud_watch_logs_role_arn  = aws_iam_role.cloudtrail_role.arn
 }
 
 resource "aws_s3_bucket" "cloudtrail_logs" {

--- a/scenarios/detection_evasion/terraform/cloudwatch.tf
+++ b/scenarios/detection_evasion/terraform/cloudwatch.tf
@@ -12,29 +12,29 @@ resource "aws_cloudwatch_log_metric_filter" "honeytoken_is_used" {
   log_group_name = aws_cloudwatch_log_group.main.name
 
   metric_transformation {
-    name      = "honeytoken_is_used"
-    namespace = "cloudgoat_detection_evasion"
-    value     = "1"
+    name          = "honeytoken_is_used"
+    namespace     = "cloudgoat_detection_evasion"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "honeytoken_alarm" {
-  alarm_name                = "honeytoken_alarm"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  metric_name               = "honeytoken_is_used"
-  namespace                 = "cloudgoat_detection_evasion"
+  alarm_name          = "honeytoken_alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "honeytoken_is_used"
+  namespace           = "cloudgoat_detection_evasion"
 
-  period                    = "60"
-  evaluation_periods        = "1"
-  threshold                 = "1"
-  datapoints_to_alarm        = "1"
+  period              = "60"
+  evaluation_periods  = "1"
+  threshold           = "1"
+  datapoints_to_alarm = "1"
 
   statistic                 = "Sum"
   alarm_description         = "Alerts on the usage of honeytokens"
   insufficient_data_actions = []
-  actions_enabled = "true"
-  alarm_actions = [aws_sns_topic.honeytoken_detected.arn]
+  actions_enabled           = "true"
+  alarm_actions             = [aws_sns_topic.honeytoken_detected.arn]
 }
 
 // resources for detecting/alerting on abnormal instance_profile usage
@@ -44,27 +44,27 @@ resource "aws_cloudwatch_log_metric_filter" "instance_profile_abnormal_usage" {
   log_group_name = aws_cloudwatch_log_group.main.name
 
   metric_transformation {
-    name      = "instance_profile_abnormal_usage"
-    namespace = "cloudgoat_detection_evasion"
-    value     = "1"
+    name          = "instance_profile_abnormal_usage"
+    namespace     = "cloudgoat_detection_evasion"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "instance_profile_alarm" {
-  alarm_name                = "instance_profile_alarm"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  metric_name               = "instance_profile_abnormal_usage"
-  namespace                 = "cloudgoat_detection_evasion"
+  alarm_name          = "instance_profile_alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "instance_profile_abnormal_usage"
+  namespace           = "cloudgoat_detection_evasion"
 
-  period                    = "60"
-  evaluation_periods        = "1"
-  threshold                 = "1"
-  datapoints_to_alarm        = "1"
+  period              = "60"
+  evaluation_periods  = "1"
+  threshold           = "1"
+  datapoints_to_alarm = "1"
 
   statistic                 = "Sum"
   alarm_description         = "Alarms on the usage of instance_profile credentials from an IP other than that of the ec2 instance associated with the profile."
   insufficient_data_actions = []
-  actions_enabled = "true"
-  alarm_actions = [aws_sns_topic.instance_profile_abnormally_used.arn]
+  actions_enabled           = "true"
+  alarm_actions             = [aws_sns_topic.instance_profile_abnormally_used.arn]
 }

--- a/scenarios/detection_evasion/terraform/data_sources.tf
+++ b/scenarios/detection_evasion/terraform/data_sources.tf
@@ -1,2 +1,27 @@
 #AWS Account Id
 data "aws_caller_identity" "aws-account-id" {}
+
+data "aws_ami" "amz_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-kernel-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}

--- a/scenarios/detection_evasion/terraform/data_sources.tf
+++ b/scenarios/detection_evasion/terraform/data_sources.tf
@@ -1,4 +1,2 @@
 #AWS Account Id
 data "aws_caller_identity" "aws-account-id" {}
-
-data "aws_region" "current" {}

--- a/scenarios/detection_evasion/terraform/ec2.tf
+++ b/scenarios/detection_evasion/terraform/ec2.tf
@@ -1,15 +1,15 @@
 
 
 resource "aws_instance" "easy_path" {
-  ami           = "ami-033b95fb8079dc481"
-  instance_type = "t2.micro"
+  ami                         = "ami-033b95fb8079dc481"
+  instance_type               = "t2.micro"
   associate_public_ip_address = true
-  iam_instance_profile = aws_iam_instance_profile.ec2_instance_profile_easy_path.name
+  iam_instance_profile        = aws_iam_instance_profile.ec2_instance_profile_easy_path.name
   // Do I even need the below key since I'm using ssm?
   // key_name = "delete-this-key-now" 
-  subnet_id = aws_subnet.main.id
+  subnet_id              = aws_subnet.main.id
   vpc_security_group_ids = [aws_security_group.main2.id]
-  user_data = <<EOF
+  user_data              = <<EOF
   #!/bin/bash
   cd /tmp
   sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
@@ -18,7 +18,7 @@ resource "aws_instance" "easy_path" {
   sudo yum remove awscli.noarch -y
   EOF
   tags = {
-    Name = "easy_path-cg-detection-evasion",
+    Name    = "easy_path-cg-detection-evasion",
     tag-key = var.cgid
   }
 }
@@ -28,12 +28,12 @@ resource "aws_instance" "hard_path" {
   instance_type = "t2.micro"
   // private_ip = "${var.target_IP}"
   // associate_public_ip_address = true
-  subnet_id = aws_subnet.main.id
+  subnet_id            = aws_subnet.main.id
   iam_instance_profile = aws_iam_instance_profile.ec2_instance_profile_hard_path.name
   // Do I even need the below key since I'm using ssm?
   // key_name = "delete-this-key-now" 
   vpc_security_group_ids = [aws_security_group.main.id]
-  user_data = <<EOF
+  user_data              = <<EOF
   #!/bin/bash
   cd /tmp
   sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
@@ -41,7 +41,7 @@ resource "aws_instance" "hard_path" {
   sudo systemctl start amazon-ssm-agent
   EOF
   tags = {
-    Name = "hard_path-cg-detection-evasion",
+    Name    = "hard_path-cg-detection-evasion",
     tag-key = var.cgid
   }
 }
@@ -52,18 +52,18 @@ resource "aws_security_group" "main" {
   vpc_id      = aws_vpc.main.id
 
   ingress {
-    description      = "HTTP"
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
+    description = "HTTP"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {
@@ -77,18 +77,18 @@ resource "aws_security_group" "main2" {
   vpc_id      = aws_vpc.main.id
 
   ingress {
-    description      = "HTTP"
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
+    description = "HTTP"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "all"
-    cidr_blocks      = ["0.0.0.0/0"]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "all"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {

--- a/scenarios/detection_evasion/terraform/ec2.tf
+++ b/scenarios/detection_evasion/terraform/ec2.tf
@@ -1,7 +1,7 @@
 
 
 resource "aws_instance" "easy_path" {
-  ami                         = "ami-033b95fb8079dc481"
+  ami                         = data.aws_ami.amz_linux.image_id
   instance_type               = "t2.micro"
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.ec2_instance_profile_easy_path.name
@@ -24,7 +24,7 @@ resource "aws_instance" "easy_path" {
 }
 
 resource "aws_instance" "hard_path" {
-  ami           = "ami-033b95fb8079dc481"
+  ami           = data.aws_ami.amz_linux.image_id
   instance_type = "t2.micro"
   // private_ip = "${var.target_IP}"
   // associate_public_ip_address = true

--- a/scenarios/detection_evasion/terraform/ec2.tf
+++ b/scenarios/detection_evasion/terraform/ec2.tf
@@ -7,6 +7,7 @@ resource "aws_instance" "easy_path" {
   iam_instance_profile = aws_iam_instance_profile.ec2_instance_profile_easy_path.name
   // Do I even need the below key since I'm using ssm?
   // key_name = "delete-this-key-now" 
+  subnet_id = aws_subnet.main.id
   vpc_security_group_ids = [aws_security_group.main2.id]
   user_data = <<EOF
   #!/bin/bash
@@ -73,6 +74,7 @@ resource "aws_security_group" "main" {
 resource "aws_security_group" "main2" {
   name        = "${var.cgid}2"
   description = "Allow HTTP traffic"
+  vpc_id      = aws_vpc.main.id
 
   ingress {
     description      = "HTTP"

--- a/scenarios/detection_evasion/terraform/iam.tf
+++ b/scenarios/detection_evasion/terraform/iam.tf
@@ -70,7 +70,7 @@ resource "aws_iam_group_policy_attachment" "test-attach" {
 resource "aws_iam_group_policy" "developer_policy" {
   name  = "developer_policy"
   group = aws_iam_group.developers.name
-  
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -83,11 +83,11 @@ resource "aws_iam_group_policy" "developer_policy" {
           "ssm:StartSession"
         ]
         Resource = [
-            "arn:aws:ssm:*:*:patchbaseline/*",
-            "arn:aws:ssm:*:*:managed-instance/*",
-            "arn:aws:ec2:*:*:instance/*",
-            "arn:aws:ssm:*:*:session/*",
-            "arn:aws:ssm:*:*:document/*"
+          "arn:aws:ssm:*:*:patchbaseline/*",
+          "arn:aws:ssm:*:*:managed-instance/*",
+          "arn:aws:ec2:*:*:instance/*",
+          "arn:aws:ssm:*:*:session/*",
+          "arn:aws:ssm:*:*:document/*"
         ]
       },
     ]
@@ -151,21 +151,21 @@ resource "aws_iam_role_policy" "instance_profile_easy_path" {
         Resource = "*"
       },
       {
-        "Effect": "Allow",
-        "Action": [
-            "secretsmanager:GetSecretValue",
+        "Effect" : "Allow",
+        "Action" : [
+          "secretsmanager:GetSecretValue",
         ],
-        "Resource": aws_secretsmanager_secret.easy_secret.arn
+        "Resource" : aws_secretsmanager_secret.easy_secret.arn
       },
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "secretsmanager:ListSecrets",
           "secretsmanager:GetResourcePolicy",
           "secretsmanager:DescribeSecret",
           "secretsmanager:ListSecretVersionIds"
         ]
-        "Resource": "*"
+        "Resource" : "*"
       }
     ]
   })
@@ -228,21 +228,21 @@ resource "aws_iam_role_policy" "instance_profile_hard_path" {
         Resource = "*"
       },
       {
-        "Effect": "Allow",
-        "Action": [
-            "secretsmanager:GetSecretValue",
+        "Effect" : "Allow",
+        "Action" : [
+          "secretsmanager:GetSecretValue",
         ],
-        "Resource": aws_secretsmanager_secret.hard_secret.arn
+        "Resource" : aws_secretsmanager_secret.hard_secret.arn
       },
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "secretsmanager:ListSecrets",
           "secretsmanager:GetResourcePolicy",
           "secretsmanager:DescribeSecret",
           "secretsmanager:ListSecretVersionIds"
         ]
-        "Resource": "*"
+        "Resource" : "*"
       }
     ]
   })

--- a/scenarios/detection_evasion/terraform/outputs.tf
+++ b/scenarios/detection_evasion/terraform/outputs.tf
@@ -3,28 +3,28 @@ output "user4_access_key_id" {
   value = aws_iam_access_key.r_waterhouse.id
 }
 output "user4_secret_key" {
-  value = aws_iam_access_key.r_waterhouse.secret
+  value     = aws_iam_access_key.r_waterhouse.secret
   sensitive = true
 }
 output "user1_access_key_id" {
   value = aws_iam_access_key.canarytoken_user.id
 }
 output "user1_secret_key" {
-  value = aws_iam_access_key.canarytoken_user.secret
+  value     = aws_iam_access_key.canarytoken_user.secret
   sensitive = true
 }
 output "user2_access_key_id" {
   value = aws_iam_access_key.spacecrab_user.id
 }
 output "user2_secret_key" {
-  value = aws_iam_access_key.spacecrab_user.secret
+  value     = aws_iam_access_key.spacecrab_user.secret
   sensitive = true
 }
 output "user3_access_key_id" {
   value = aws_iam_access_key.spacesiren_user.id
 }
 output "user3_secret_key" {
-  value = aws_iam_access_key.spacesiren_user.secret
+  value     = aws_iam_access_key.spacesiren_user.secret
   sensitive = true
 }
 #AWS Account ID

--- a/scenarios/detection_evasion/terraform/provider.tf
+++ b/scenarios/detection_evasion/terraform/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   profile = var.profile
-  region = var.region
+  region  = var.region
 
   default_tags {
     tags = {

--- a/scenarios/detection_evasion/terraform/secrets_manager.tf
+++ b/scenarios/detection_evasion/terraform/secrets_manager.tf
@@ -1,6 +1,6 @@
 resource "aws_secretsmanager_secret" "easy_secret" {
-  name = "${var.cgid}_easy_secret"
-  description = "This is the final secret for the 'easy' path of the detection_evasion cloudgoat scenario."
+  name                    = "${var.cgid}_easy_secret"
+  description             = "This is the final secret for the 'easy' path of the detection_evasion cloudgoat scenario."
   recovery_window_in_days = 0
 }
 
@@ -10,8 +10,8 @@ resource "aws_secretsmanager_secret_version" "easy_secret_value" {
 }
 
 resource "aws_secretsmanager_secret" "hard_secret" {
-  name = "${var.cgid}_hard_secret"
-  description = "This is the final secret for the 'hard' path of the detection_evasion cloudgoat scenario."
+  name                    = "${var.cgid}_hard_secret"
+  description             = "This is the final secret for the 'hard' path of the detection_evasion cloudgoat scenario."
   recovery_window_in_days = 0
 }
 

--- a/scenarios/detection_evasion/terraform/variables.tf
+++ b/scenarios/detection_evasion/terraform/variables.tf
@@ -1,31 +1,37 @@
 variable "profile" {
   description = "The AWS profile to use."
+  type        = string
 }
 
 variable "region" {
   description = "The AWS region to deploy resources to."
-  default = "us-east-1"
+  default     = "us-east-1"
+  type        = string
 }
 
 variable "cgid" {
   description = "CGID variable for unique naming."
+  type        = string
 }
 
 variable "cg_whitelist" {
   description = "User's public IP address(es)."
-  type = list(string)
+  type        = list(string)
 }
 
 variable "stack-name" {
   description = "Name of the stack."
-  default = "CloudGoat"
+  default     = "CloudGoat"
+  type        = string
 }
 
 variable "scenario-name" {
   description = "Name of the scenario."
-  default = "detection-evasion"
+  default     = "detection-evasion"
+  type        = string
 }
 
 variable "user_email" {
   description = "The email used in conjunction with sns to deliver alerts."
+  type        = string
 }

--- a/scenarios/detection_evasion/terraform/vpc.tf
+++ b/scenarios/detection_evasion/terraform/vpc.tf
@@ -1,8 +1,8 @@
 resource "aws_vpc" "main" {
-  cidr_block       = "3.84.104.0/24"
-  instance_tenancy = "default"
-  enable_dns_support = true
-  enable_dns_hostnames  = true 
+  cidr_block           = "3.84.104.0/24"
+  instance_tenancy     = "default"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
   tags = {
     tag-key = var.cgid
   }
@@ -17,13 +17,38 @@ resource "aws_subnet" "main" {
   }
 }
 
+resource "aws_internet_gateway" "internet_gateway" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    tag-key = var.cgid
+  }
+}
+
+resource "aws_route_table" "subnet_route_table" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.internet_gateway.id
+  }
+
+  tags = {
+    tag-key = var.cgid
+  }
+}
+
+resource "aws_route_table_association" "subnet_route_association" {
+  subnet_id      = aws_subnet.main.id
+  route_table_id = aws_route_table.subnet_route_table.id
+}
+
 // VPC ENDPOINTS BELOW
 resource "aws_vpc_endpoint" "sts" {
-  vpc_id       = aws_vpc.main.id
-  service_name = "com.amazonaws.${var.region}.sts"
-  vpc_endpoint_type = "Interface"
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.sts"
+  vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
-  subnet_ids = [aws_subnet.main.id]
+  subnet_ids          = [aws_subnet.main.id]
   security_group_ids = [
     aws_security_group.main.id,
   ]
@@ -34,10 +59,10 @@ resource "aws_vpc_endpoint" "sts" {
 }
 
 resource "aws_vpc_endpoint" "ssm" {
-  vpc_id       = aws_vpc.main.id
-  service_name = "com.amazonaws.${var.region}.ssm"
-  vpc_endpoint_type = "Interface"
-  subnet_ids = [aws_subnet.main.id]
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.ssm"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.main.id]
   private_dns_enabled = true
   security_group_ids = [
     aws_security_group.main.id,
@@ -49,10 +74,10 @@ resource "aws_vpc_endpoint" "ssm" {
 }
 
 resource "aws_vpc_endpoint" "ec2messages" {
-  vpc_id       = aws_vpc.main.id
-  service_name = "com.amazonaws.${var.region}.ec2messages"
-  vpc_endpoint_type = "Interface"
-  subnet_ids = [aws_subnet.main.id]
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.ec2messages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.main.id]
   private_dns_enabled = true
   security_group_ids = [
     aws_security_group.main.id,
@@ -63,26 +88,11 @@ resource "aws_vpc_endpoint" "ec2messages" {
   }
 }
 
-// resource "aws_vpc_endpoint" "ec2" {
-//   vpc_id       = aws_vpc.main.id
-//   service_name = "com.amazonaws.${var.region}.ec2"
-//   vpc_endpoint_type = "Interface"
-//   subnet_ids = ["${aws_subnet.main.id}"]
-//   private_dns_enabled = true
-//   security_group_ids = [
-//     aws_security_group.main.id,
-//   ]
-
-//   tags = {
-//     tag-key = "${var.cgid}"
-//   }
-// }
-
 resource "aws_vpc_endpoint" "ssmmessages" {
-  vpc_id       = aws_vpc.main.id
-  service_name = "com.amazonaws.${var.region}.ssmmessages"
-  vpc_endpoint_type = "Interface"
-  subnet_ids = [aws_subnet.main.id]
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.ssmmessages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.main.id]
   private_dns_enabled = true
   security_group_ids = [
     aws_security_group.main.id,
@@ -94,10 +104,10 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 }
 
 resource "aws_vpc_endpoint" "logs" {
-  vpc_id       = aws_vpc.main.id
-  service_name = "com.amazonaws.${var.region}.logs"
-  vpc_endpoint_type = "Interface"
-  subnet_ids = [aws_subnet.main.id]
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.main.id]
   private_dns_enabled = true
   security_group_ids = [
     aws_security_group.main.id,


### PR DESCRIPTION
#### Changes
- Add internet gateway to VPC, the easy server could not communicate with the public internet
  - Hard still cannot talk to internet/secretmanager (no route)
- Add subnet Ids on easy EC2 instance
  - Error (`VPCIdNotSpecified: No default VPC for this user`)
- Pull the EC2 AMI dynamically, will work in other regions
- linting
- formatting (`terraform fmt`)

#### Test
Tested with Terraform `1.5.6`