### PR TITLE
ECS Takeover | x86_64 AMI

### DIFF
--- a/scenarios/ecs_takeover/terraform/ec2.tf
+++ b/scenarios/ecs_takeover/terraform/ec2.tf
@@ -11,6 +11,11 @@ data "aws_ami" "ecs" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
 }
 
 locals {


### PR DESCRIPTION
#### Change
- Require the image to be `x86_64`
  - https://github.com/RhinoSecurityLabs/cloudgoat/issues/209
  - https://github.com/RhinoSecurityLabs/cloudgoat/issues/205

#### Testing
Terraform `1.5.6`