### PR TITLE
an error when running ./cloudgoat.py create codebuild_secrets

### DIFF
--- a/scenarios/codebuild_secrets/terraform/rds.tf
+++ b/scenarios/codebuild_secrets/terraform/rds.tf
@@ -63,7 +63,7 @@ resource "aws_db_instance" "cg-psql-rds" {
   ]
   storage_type = "gp2"
   allocated_storage = 20
-  name = "${var.rds-database-name}"
+  db_name = "${var.rds-database-name}"
   apply_immediately = true
   skip_final_snapshot = true
 


### PR DESCRIPTION
![screenshot](https://github.com/RhinoSecurityLabs/cloudgoat/assets/138341927/a09ceff3-0ce1-49c3-8856-8b86a48d85c6)

I found it at scenarios/codebuild_secrets/terraform/rds.tf.
It seems that argument _"name"_ need to be changed to _"db_name"_.

I referred to the terraform official document.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance

I would appreciate it if you could leave a comment.
Thank you.