### PR TITLE
Fix Typo in README.md

### DIFF
--- a/scenarios/ecs_takeover/README.md
+++ b/scenarios/ecs_takeover/README.md
@@ -2,7 +2,7 @@
 
 **Size:** Medium
 
-**Difficulty:** Medium
+**Difficulty:** Moderate
 
 **Command:** `$ ./cloudgoat.py create ecs_takeover`
 


### PR DESCRIPTION
Fix Typo in README.md on ecs_takeover scenario.

The difficulty level of the scenario is written as Medium, so I changed it to Moderate.