### PR TITLE
Recommend Python Virtual Environment & Update Modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ trash/
 # Editors
 .idea
 .sw[a-z]
+
+# Python virtual environment
+.venv

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ To install CloudGoat, make sure your system meets the requirements above, and th
 ```
 git clone https://github.com/RhinoSecurityLabs/cloudgoat.git
 cd cloudgoat
+python3 -m venv .venv
+source .venv/bin/activate
 pip3 install -r ./requirements.txt
 chmod +x cloudgoat.py
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 # black==19.3b0
 # flake8==3.7.7
 
-argcomplete==1.10.0
-PyYAML==6.0.1
-boto3==1.18.1  # The ecs_takeover scenario assumes boto3 is available
-requests==2.26.0
-sqlite-utils==3.17
+argcomplete~=3.2.3
+PyYAML~=6.0.1
+boto3~=1.34.77  # The ecs_takeover scenario assumes boto3 is available
+requests~=2.31.0
+sqlite-utils~=3.36


### PR DESCRIPTION
#### Overview of Changes
- Recommend using python virtual environments
  - Git ignore the `.venv` directory
- Updated python packages to latest versions

#### Testing
Locally running scenarios (including ecs_takeover)

#### Rational
Without setting up virtual environments the following error is raised.
```
❯ pip3 install -r ./requirements.txt
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-brew-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.

    If you wish to install a non-brew packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
```