### PR TITLE
Updated codebuild-secrets RDS to 16.2

### DIFF
--- a/scenarios/codebuild_secrets/terraform/rds.tf
+++ b/scenarios/codebuild_secrets/terraform/rds.tf
@@ -50,7 +50,7 @@ resource "aws_db_subnet_group" "cg-rds-testing-subnet-group" {
 resource "aws_db_instance" "cg-psql-rds" {
   identifier = "cg-rds-instance-${local.cgid_suffix}"
   engine = "postgres"
-  engine_version = "13.7"
+  engine_version = "16.2"
   port = "5432"
   instance_class = "db.m5.large"
   db_subnet_group_name = "${aws_db_subnet_group.cg-rds-subnet-group.id}"


### PR DESCRIPTION
#### Overview of Changes
- Update from PostgreSQL `13.7 -> 16.2` 
  - 13.7 is now outdated and not supported by AWS

```
Error: creating RDS DB Instance (cg-rds-instance-codebuild-secrets-cgidutxr0a5lqu): InvalidParameterCombination: Cannot find version 
13.7 for postgres
```

#### Testing
Ran through the scenario and confirmed that flags are still populated by the EC2 user-data script.

#### Note
Planning to go back through this scenario later and refactor the Terraform