### PR TITLE
Cleanup Scenarios Resources in Readme

### DIFF
--- a/scenarios/cicd/README.md
+++ b/scenarios/cicd/README.md
@@ -8,12 +8,13 @@
 
 ## Scenario Resources
 
-* 3 IAM users
-* 1 VPC with 1 EC2 instance
-* 1 API Gateway
-* 1 Lambda function
-* 1 ECR image
-* 2 CodeBuild project (and an additional out of scope)
+- 3 IAM users
+- 1 VPC:
+  - 1 EC2 Instance
+- 1 API Gateway
+- 1 Lambda function
+- 1 ECR image
+- 2 CodeBuild project (and an additional out of scope)
 
 ## Scenario Start
 

--- a/scenarios/cloud_breach_s3/README.md
+++ b/scenarios/cloud_breach_s3/README.md
@@ -8,9 +8,9 @@
 
 ## Scenario Resources
 
-* 1 VPC with:
-  * EC2 x 1
-  * S3 x 1
+- 1 VPC
+  - 1 EC2 Instance
+  - 1 S3 Bucket
 
 ## Scenario Start(s)
 

--- a/scenarios/codebuild_secrets/README.md
+++ b/scenarios/codebuild_secrets/README.md
@@ -9,10 +9,10 @@
 ## Scenario Resources
 
 - 1 CodeBuild Project
-- 1 Lambda function
-- 1 VPC with:
-  - RDS x 1
-  - EC2 x 1
+- 1 Lambda Function
+- 1 VPC:
+  - 1 RDS Database
+  - 1 EC2 Instance
 - 2 IAM Users
 - 2 SSM Parameters
 

--- a/scenarios/ec2_ssrf/README.md
+++ b/scenarios/ec2_ssrf/README.md
@@ -8,10 +8,11 @@
 
 ## Scenario Resources
 
-- 1 VPC with:
-	- EC2 x 1
+- 1 VPC
+	- 1 EC2
 - 1 Lambda Function
 - 1 S3 Bucket
+- 3 IAM Users
 
 ## Scenario Start(s)
 

--- a/scenarios/ecs_efs_attack/README.md
+++ b/scenarios/ecs_efs_attack/README.md
@@ -8,10 +8,10 @@
 
 ## Scenario Resources
 
-- 1 VPC with:
-	- EC2 x 2
+- 1 VPC:
+	- 2 EC2 Instances
 	- 1 ECS Cluster
-	- 1 ECS Service 
+	- 1 ECS Service
 	- 1 EFS
 
 ## Scenario Start(s)

--- a/scenarios/ecs_takeover/README.md
+++ b/scenarios/ecs_takeover/README.md
@@ -9,10 +9,10 @@
 ## Scenario Resources
 
 - 1 VPC and Subnet with:
-    - 2 EC2 Instances
-    - 1 ECS Cluster
-    - 3 ECS Services
-    - 1 Internet Gateway
+  - 2 EC2 Instances
+  - 1 ECS Cluster
+  - 3 ECS Services
+  - 1 Internet Gateway
 
 ## Scenario Start(s)
 

--- a/scenarios/glue_privesc/README.md
+++ b/scenarios/glue_privesc/README.md
@@ -8,14 +8,14 @@
 
 ## Scenario Resources
 
-- 1 VPC with:
-    - S3  x 1
-    - RDS x1
-    - EC2 x1
-    - Glue service
-- Lambda x1
+- 1 VPC:
+  - 2 EC2 Instances
+  - RDS Database
+  - Glue service
+- S3 Bucket
+- 1 Lambda Function
 - SSM parameter Store
-- IAM Users x 2
+- 2 IAM Users
 
 ## Scenario Start(s)
 

--- a/scenarios/iam_privesc_by_attachment/README.md
+++ b/scenarios/iam_privesc_by_attachment/README.md
@@ -8,9 +8,10 @@
 
 ## Scenario Resources
 
-* 1 VPC with:
-  * EC2 x 1
-* 1 IAM User
+- 1 VPC:
+  - 1 EC2 Instance
+- 1 IAM User
+- 2 IAM Roles
 
 ## Scenario Start(s)
 

--- a/scenarios/iam_privesc_by_rollback/README.md
+++ b/scenarios/iam_privesc_by_rollback/README.md
@@ -8,8 +8,8 @@
 
 ## Scenario Resources
 
-* 1 IAM User
-  * 5 policy versions
+- 1 IAM User
+  - 5 policy versions
 
 ## Scenario Start(s)
 

--- a/scenarios/lambda_privesc/README.md
+++ b/scenarios/lambda_privesc/README.md
@@ -1,19 +1,20 @@
 
 # Scenario: lambda_privesc
 
-**Size:** Small  
+**Size:** Small
+
 **Difficulty:** Easy
 
 **Command:** `$ ./cloudgoat.py create lambda_privesc`
 
 ## Scenario Resources
 
-1 IAM User  
-2 IAM Roles  
+- 1 IAM User  
+- 2 IAM Roles  
 
 ## Scenario Start(s)
 
-1. IAM User Chris  
+1. IAM User Chris
 
 ## Scenario Goal(s)
 
@@ -21,7 +22,7 @@ Acquire full admin privileges.
 
 ## Summary
 
-Starting as the IAM user Chris, the attacker discovers that they can assume a role that has full Lambda access and pass role permissions. The attacker can then perform privilege escalation to obtain full admin access.  
+Starting as the IAM user Chris, the attacker discovers that they can assume a role that has full Lambda access and pass role permissions. The attacker can then perform privilege escalation to obtain full admin access.
 
 Note: This scenario may require you to create some AWS resources, and because CloudGoat can only manage resources it creates, you should remove them manually before running `./cloudgoat destroy`.
 

--- a/scenarios/rce_web_app/README.md
+++ b/scenarios/rce_web_app/README.md
@@ -8,12 +8,12 @@
 
 ## Scenario Resources
 
-* 1 VPC with:
-  * ELB x 1
-  * EC2 x 1
-  * S3 x 3
-  * RDS x 1
-* 2 IAM Users
+- 1 VPC:
+  - 1 ELB
+  - 1 EC2 Instance
+  - 1 RDS Database
+- 2 IAM Users
+- 3 S3 Buckets
 
 ## Scenario Start(s)
 

--- a/scenarios/rds_snapshot/README.md
+++ b/scenarios/rds_snapshot/README.md
@@ -8,11 +8,11 @@
 
 ## Scenario Resources
 
-* 1 VPC with:
-  * EC2 x 1
-  * S3 x 1
-  * RDS x 1
-* 1 IAM Users
+- 1 VPC:
+  - 1 EC2 Instance
+  - 1 RDS Database
+- 1 IAM Users
+- 1 S3 Bucket
 
 ## Scenario Start(s)
 

--- a/scenarios/sns_secrets/README.md
+++ b/scenarios/sns_secrets/README.md
@@ -10,11 +10,11 @@
 
 ## Scenario Resources
 
-- 1 EC2 instance
 - 1 SNS topic
 - 1 API Gateway REST API
 - 1 IAM role
 - 1 IAM user
+- 1 Lambda Function
 
 ## Scenario Start(s)
 

--- a/scenarios/sqs_flag_shop/README.md
+++ b/scenarios/sqs_flag_shop/README.md
@@ -8,12 +8,12 @@
 
 ### Scenario Resources
 
-- 1 VPC with:
-    - Lambda  x 1
-    - RDS x1
-    - EC2 x1
+- 1 VPC:
+  - 1 RDS Database
+  - 1 EC2 Instance
 - SQS
-- IAM Users x 1
+- Lambda Function
+- 1 IAM User
 
 ### Scenario Start(s)
 

--- a/scenarios/sqs_flag_shop/terraform/iam.tf
+++ b/scenarios/sqs_flag_shop/terraform/iam.tf
@@ -51,8 +51,8 @@ resource "aws_iam_role_policy" "cg-sqs_scenario_policy" {
 }
 
 resource "aws_iam_user_policy" "cg-sqs_scenario_assumed_role_policy" {
-  name   = "cg-sqs-scenario-assumed-role-policy"
-  user   = aws_iam_user.cg-sqs-user.name
+  name = "cg-sqs-scenario-assumed-role-policy"
+  user = aws_iam_user.cg-sqs-user.name
 
   policy = jsonencode({
     Version = "2012-10-17",
@@ -67,9 +67,9 @@ resource "aws_iam_user_policy" "cg-sqs_scenario_assumed_role_policy" {
         Resource = "*",
       },
       {
-        Sid    = "VisualEditor1",
-        Effect = "Allow",
-        Action = "sts:AssumeRole",
+        Sid      = "VisualEditor1",
+        Effect   = "Allow",
+        Action   = "sts:AssumeRole",
         Resource = aws_iam_role.cg-sqs_send_msg_role.arn,
       },
     ],

--- a/scenarios/sqs_flag_shop/terraform/lambda.tf
+++ b/scenarios/sqs_flag_shop/terraform/lambda.tf
@@ -17,8 +17,8 @@ resource "aws_lambda_function" "charging_cash_lambda" {
 
   environment {
     variables = {
-      web_url    = "http://${aws_instance.cg_flag_shop_server.public_ip}:5000/sqs_process"
-      auth = var.sqs_auth
+      web_url = "http://${aws_instance.cg_flag_shop_server.public_ip}:5000/sqs_process"
+      auth    = var.sqs_auth
     }
   }
 }

--- a/scenarios/sqs_flag_shop/terraform/rds.tf
+++ b/scenarios/sqs_flag_shop/terraform/rds.tf
@@ -44,6 +44,6 @@ resource "aws_db_subnet_group" "cg-rds-subnet-group" {
 }
 
 resource "local_file" "sql_file" {
-  content  = templatefile("${path.module}/../assets/init_rds.tpl",{})
+  content  = templatefile("${path.module}/../assets/init_rds.tpl", {})
   filename = "../assets/insert_data.sql"
 }

--- a/scenarios/sqs_flag_shop/terraform/sg.tf
+++ b/scenarios/sqs_flag_shop/terraform/sg.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "cg-ec2-security-group" {
     from_port   = 5000
     to_port     = 5000
     protocol    = "tcp"
-    cidr_blocks = var.cg_whitelist 
+    cidr_blocks = var.cg_whitelist
   }
   egress {
     from_port   = 0

--- a/scenarios/vulnerable_cognito/README.md
+++ b/scenarios/vulnerable_cognito/README.md
@@ -8,12 +8,13 @@
 
 ## Scenario Resources
 
-1 S3 bucket
-1 Cognito Userpool
-1 Cognito IdentityPool
-1 API Gateway REST API
-1 Lambda
-1 IAM role
+- S3 bucket
+- Cognito
+  - Userpool
+  - IdentityPool
+- API Gateway REST API
+- Lambda Function
+- 3 IAM roles
 
 ## Scenario Start(s)
 

--- a/scenarios/vulnerable_lambda/README.md
+++ b/scenarios/vulnerable_lambda/README.md
@@ -1,21 +1,21 @@
 
 # Scenario: vulnerable_lambda
 
-**Size:** Small  
+**Size:** Small
 **Difficulty:** Easy
 
 **Command:** `$ ./cloudgoat.py create vulnerable_lambda`
 
 ## Scenario Resources
 
-1 IAM User  
-1 IAM Role  
-1 Lambda   
-1 Secret 
+- 1 IAM User
+- 2 IAM Roles
+- 1 Lambda Function
+- 1 SecretManager Secret
 
 ## Scenario Start(s)
 
-1. IAM User 'bilbo' 
+1. IAM User 'bilbo'
 
 ## Scenario Goal(s)
 
@@ -25,7 +25,7 @@ Find the scenario's secret. (cg-secret-XXXXXX-XXXXXX)
 
 In this scenario, you start as the 'bilbo' user. You will assume a role with more privileges, discover a 
 lambda function that applies policies to users, and exploit a vulnerability in the function to escalate 
-the privileges of the bilbo user in order to search for secrets. 
+the privileges of the bilbo user in order to search for secrets.
 
 ## Exploitation Route
 
@@ -41,7 +41,7 @@ the privileges of the bilbo user in order to search for secrets.
 5. Assume the lambda invoker role.
 6. Craft an injection payload to send through the CLI.
 7. Base64 encode that payload. The single quote injection character is not compatible with the aws cli command otherwise.
-8. Invoke the policy applier lambda function, passing the name of the bilbo user and the injection payload. 
-9. Now that Bilbo is an admin, use credentials for that user to list secrets from secretsmanager. 
+8. Invoke the policy applier lambda function, passing the name of the bilbo user and the injection payload.
+9. Now that Bilbo is an admin, use credentials for that user to list secrets from secretsmanager.
 
 A cheat sheet for this route is available [here](./cheat_sheet.md).


### PR DESCRIPTION
#### Overview of Changes
- Noticed that the `sns_secrets` scenario still showed it using an EC2 instances (#271)
- Then I went through all the scenarios and updated the formatting
  - I incorporated the changes from https://github.com/RhinoSecurityLabs/cloudgoat/pull/196 which can be closed after this gets merged
- Ran a `terraform fmt` on some resources

#### Testing
N/A
