### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Before you proceed, please take note of these warnings!
 * Linux or MacOS. Windows is not officially supported.
   * Argument tab-completion requires bash 4.2+ (Linux, or OSX with some difficulty).
 * Python3.6+ is required.
-* Terraform >= 0.14 [installed and in your $PATH](https://learn.hashicorp.com/terraform/getting-started/install.html).
+* Terraform >= 1.5.0 [installed and in your $PATH](https://learn.hashicorp.com/terraform/getting-started/install.html).
 * The AWS CLI [installed and in your $PATH](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html), and an AWS account with sufficient privileges to create and destroy resources.
 * [jq](https://stedolan.github.io/jq/)
 


### PR DESCRIPTION
Some scenarios require 1.5.0. The min required version should probably support all scenarios.

#### Overview of Changes
- Updated min required version in the readme

#### Testing
All scenarios pass terraform validate and terraform plan with terraform v 1.5.0+. Lower versions of terraform result in failures.