### PR TITLE
Update Name Regex in beanstalk_secrets terraform

### DIFF
--- a/cloudgoat/scenarios/aws/beanstalk_secrets/terraform/ec2.tf
+++ b/cloudgoat/scenarios/aws/beanstalk_secrets/terraform/ec2.tf
@@ -4,7 +4,7 @@
 
 data "aws_elastic_beanstalk_solution_stack" "python_stack" {
   most_recent = true # Get the latest version matching the regex
-  name_regex  = "^.*running Python.*$"
+  name_regex  = "^64bit Amazon Linux 2023.*running Python 3.11$"
 }
 
 


### PR DESCRIPTION
#### Overview of Changes
I have a very minor update to the name regex for the Beanstalk Secrets scenario. A user on Discord reported an error that the scenario wouldn't launch in their region. This is due to it pulling too new of a version of Python and it not matching the OS available. 

The updated regex resolves this issue. 
