### PR TITLE
Fix sns_secrets scenario

### DIFF
--- a/cloudgoat/scenarios/aws/sns_secrets/terraform/api_gateway.tf
+++ b/cloudgoat/scenarios/aws/sns_secrets/terraform/api_gateway.tf
@@ -63,14 +63,20 @@ resource "aws_api_gateway_deployment" "deployment" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.api.id
-  stage_name  = "prod-${var.cgid}"
+}
+
+resource "aws_api_gateway_stage" "stage" {
+  stage_name    = "prod-${var.cgid}"
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  deployment_id = aws_api_gateway_deployment.deployment.id
 }
 
 resource "aws_api_gateway_usage_plan" "usage_plan" {
   name = "cg-usage-plan-${var.cgid}"
+
   api_stages {
     api_id = aws_api_gateway_rest_api.api.id
-    stage  = aws_api_gateway_deployment.deployment.stage_name
+    stage  = aws_api_gateway_stage.stage.stage_name
   }
 }
 


### PR DESCRIPTION
#### Overview of Changes
This PR resolves [Issue #371](https://github.com/RhinoSecurityLabs/cloudgoat/issues/371), which was caused by the removal of the stage_name argument from the aws_api_gateway_deployment resource in Terraform AWS Provider v4+.
