### PR TITLE
Fixed destroy_all_scenarios whitelist bug

### DIFF
--- a/cloudgoat/core/python/commands.py
+++ b/cloudgoat/core/python/commands.py
@@ -443,6 +443,7 @@ class CloudGoat:
 
     def destroy_all_scenarios(self):
         # Information gathering.
+        self.cg_whitelist = self.configure_or_check_whitelist(auto=not os.path.exists(self.whitelist_path))
         extant_scenario_instance_names_and_paths = list()
         for scenario_name in self.scenario_names:
             scenario_instance_dir_path = find_scenario_instance_dir(


### PR DESCRIPTION
#### Overview of Changes
- Added a line to command.py that sets the cg_whitelist variable when the `cloudgoat destroy all` command is used. Without setting this variable, the `rds_snapshot` and `sqs_flag_shop` scenarios cannot be destroyed with the `cloudgoat destroy all` command.

#### Testing
- Created and destroyed `rds_snapshot` and `sqs_flag_shop` scenarios successfully.
