### PR TITLE
Replace hardcoded AMI with dynamic Ubuntu AMI lookup

### DIFF
--- a/cloudgoat/scenarios/aws/cloud_breach_s3/terraform/data_sources.tf
+++ b/cloudgoat/scenarios/aws/cloud_breach_s3/terraform/data_sources.tf
@@ -1,2 +1,28 @@
 #AWS Account Id
 data "aws_caller_identity" "aws-account-id" {}
+
+# Dynamic Ubuntu 22.04 AMI (region-aware)
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical (Ubuntu)
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}

--- a/cloudgoat/scenarios/aws/cloud_breach_s3/terraform/ec2.tf
+++ b/cloudgoat/scenarios/aws/cloud_breach_s3/terraform/ec2.tf
@@ -94,7 +94,7 @@ resource "aws_key_pair" "cg-ec2-key-pair" {
 
 #EC2 Instance
 resource "aws_instance" "ec2-vulnerable-proxy-server" {
-  ami                         = "ami-0a313d6098716f372"
+  ami                         = data.aws_ami.ubuntu.id
   instance_type               = "t2.micro"
   iam_instance_profile        = aws_iam_instance_profile.cg-ec2-instance-profile.name
   subnet_id                   = aws_subnet.cg-public-subnet-1.id


### PR DESCRIPTION
Fixes #376

This PR replaces the hardcoded AMI in the cloud_breach_s3 scenario
with a dynamic Terraform aws_ami data source for Ubuntu 22.04,
making the scenario region-independent.

Tested with:
- terraform fmt
- terraform init
- terraform validate
